### PR TITLE
데이터베이스 저장방식에 MYSQL 지원 추가하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 경제 플러그인입니다.
 
 ### Use Paper Version:
-1.18.2
+1.19.2
 ### Tested Paper Version:
-1.18.2
+1.19.2
 ### Required Plugin:
 - Vault
 - PlaceholderAPI (Optional)
@@ -35,6 +35,9 @@
 
 ### 플러그인 리로드 기능
 /uconomy reload 명령어를 사용하여 플러그인을 리로드할 수 있습니다.
+
+### MySQL 저장 방식 지원  
+config 파일에서 MySQL 저장 방식을 사용할 것인지 yml 파일 저장 방식을 사용할 것인지 설정할 수 있습니다.
 
 ### Uconomy Placeholders
 - %uconomy_balance%

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <version>1.19.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,5 +96,10 @@
             <version>2.11.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.0.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.teamuni</groupId>
     <artifactId>Uconomy</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <packaging>jar</packaging>
 
     <name>Uconomy</name>

--- a/src/main/java/net/teamuni/economy/Uconomy.java
+++ b/src/main/java/net/teamuni/economy/Uconomy.java
@@ -6,6 +6,7 @@ import net.teamuni.economy.command.CommandTabCompleter;
 import net.teamuni.economy.command.UconomyCmd;
 import net.teamuni.economy.config.MessageManager;
 import net.teamuni.economy.data.MoneyManager;
+import net.teamuni.economy.database.MySQLDatabase;
 import net.teamuni.economy.event.JoinEvent;
 import net.teamuni.economy.hooks.HookIntoVault;
 import net.teamuni.economy.data.EconomyManager;
@@ -14,12 +15,16 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.logging.Level;
+
 @Getter
 public final class Uconomy extends JavaPlugin {
     private HookIntoVault hookIntoVault;
     private EconomyManager economyManager;
     private MessageManager messageManager;
     private MoneyManager moneyManager;
+    private MySQLDatabase database;
+    private boolean isMySQLUse = false;
 
     @Override
     public void onEnable() {
@@ -31,6 +36,18 @@ public final class Uconomy extends JavaPlugin {
         this.messageManager.createMessagesYml();
         this.moneyManager.createMoneyDataYml();
         saveDefaultConfig();
+        this.isMySQLUse = Boolean.parseBoolean(getConfig().getString("mysql_use"));
+        if (isMySQLUse) {
+            try {
+                this.database = new MySQLDatabase(
+                        getConfig().getString("MySQL.Host"), getConfig().getInt("MySQL.Port"),
+                        getConfig().getString("MySQL.Database"), getConfig().getString("MySQL.Parameters"),
+                        getConfig().getString("MySQL.Username"), getConfig().getString("MySQL.Password"));
+            } catch (Exception e) {
+                getLogger().log(Level.SEVERE, "데이터베이스 연결에 실패하였습니다.", e);
+                this.database = null;
+            }
+        }
         Bukkit.getPluginManager().registerEvents(new JoinEvent(this), this);
         getCommand("돈").setExecutor(new UconomyCmd(this));
         getCommand("uconomy").setExecutor(new UconomyCmd(this));

--- a/src/main/java/net/teamuni/economy/Uconomy.java
+++ b/src/main/java/net/teamuni/economy/Uconomy.java
@@ -68,10 +68,11 @@ public final class Uconomy extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        this.moneyManager.save();
         this.hookIntoVault.unhook();
         if (isMySQLUse) {
             this.playerDataManager.removeAll();
+        } else {
+            this.moneyManager.save();
         }
     }
 

--- a/src/main/java/net/teamuni/economy/Uconomy.java
+++ b/src/main/java/net/teamuni/economy/Uconomy.java
@@ -2,6 +2,8 @@ package net.teamuni.economy;
 
 import lombok.Getter;
 import net.milkbowl.vault.economy.Economy;
+import net.teamuni.economy.command.CommandTabCompleter;
+import net.teamuni.economy.command.UconomyCmd;
 import net.teamuni.economy.config.MessageManager;
 import net.teamuni.economy.data.MoneyManager;
 import net.teamuni.economy.event.JoinEvent;
@@ -9,69 +11,34 @@ import net.teamuni.economy.hooks.HookIntoVault;
 import net.teamuni.economy.data.EconomyManager;
 import net.teamuni.economy.hooks.UconomyPlaceholders;
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
-
-import java.text.DecimalFormat;
-import java.util.List;
 
 @Getter
 public final class Uconomy extends JavaPlugin {
-
-    private static Uconomy instance;
-    private static EconomyManager manager;
-    private static HookIntoVault hookIntoVault;
-
-    public static Uconomy getInstance() {
-        return instance;
-    }
-
-    public static EconomyManager getEconomyManager() {
-        return manager;
-    }
-
-    List<String> reloadMessageList;
-    List<String> commandGuideMessageList;
-    List<String> opCommandGuideMessageList;
-    List<String> notAvailableCommandMessageList;
-    List<String> incorrectPlayerNameMessageList;
-    List<String> invalidSyntaxMessageList;
-    List<String> moneyShortageMessageList;
-    List<String> attemptToDepositToOneselfMessageList;
-    List<String> checkMyMoneyMessageList;
-    List<String> checkTheOtherPlayerMoneyMessageList;
-    List<String> transactionConfirmToSenderMessageList;
-    List<String> transactionConfirmToRecipientMessageList;
-    List<String> minimumAmountCautionMessageList;
-    List<String> increasePlayerMoneyMessageList;
-    List<String> decreasePlayerMoneyMessageList;
-    List<String> setPlayerMoneyMessageList;
-
-    DecimalFormat df = new DecimalFormat("###,###");
+    private HookIntoVault hookIntoVault;
+    private EconomyManager economyManager;
+    private MessageManager messageManager;
+    private MoneyManager moneyManager;
 
     @Override
     public void onEnable() {
+        this.economyManager = new EconomyManager(this);
+        this.hookIntoVault = new HookIntoVault(this);
+        this.messageManager = new MessageManager(this);
+        this.moneyManager = new MoneyManager(this);
+        this.hookIntoVault.hook();
+        this.messageManager.createMessagesYml();
+        this.moneyManager.createMoneyDataYml();
         saveDefaultConfig();
-        MoneyManager.createMoneyDataYml();
-        MessageManager.createMessagesYml();
-        Bukkit.getPluginManager().registerEvents(new JoinEvent(), this);
+        Bukkit.getPluginManager().registerEvents(new JoinEvent(this), this);
+        getCommand("돈").setExecutor(new UconomyCmd(this));
+        getCommand("uconomy").setExecutor(new UconomyCmd(this));
         getCommand("돈").setTabCompleter(new CommandTabCompleter());
         getCommand("uconomy").setTabCompleter(new CommandTabCompleter());
-        getMessages();
-        instance = this;
-        manager = new EconomyManager();
-        hookIntoVault = new HookIntoVault();
-        hookIntoVault.hook();
-
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             new UconomyPlaceholders().register();
         }
-
         if (!setupEconomy()) {
             getLogger().info("Disabled due to no Vault dependency found!");
             getServer().getPluginManager().disablePlugin(this);
@@ -80,8 +47,8 @@ public final class Uconomy extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        MoneyManager.save();
-        hookIntoVault.unhook();
+        this.moneyManager.save();
+        this.hookIntoVault.unhook();
     }
 
     private boolean setupEconomy() {
@@ -90,184 +57,5 @@ public final class Uconomy extends JavaPlugin {
         }
         RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
         return rsp != null;
-    }
-
-    @Override
-    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
-
-            if (command.getName().equalsIgnoreCase("돈")) {
-                if (args.length > 0) {
-                    switch (args[0]) {
-                        case "확인":
-                            switch (args.length) {
-                                case 1:
-                                    MessageManager.sendTranslatedMsgs(player, checkMyMoneyMessageList
-                                            , "%name_of_player%", player.getName()
-                                            , "%player_money%", df.format(getEconomyManager().getBalance(player)));
-                                    break;
-                                case 2:
-                                    if (!player.hasPermission("ucon.manage")) {
-                                        MessageManager.sendTranslatedMsgs(player, notAvailableCommandMessageList);
-                                        return false;
-                                    }
-                                    OfflinePlayer target = Bukkit.getOfflinePlayerIfCached(args[1]);
-
-                                    if (target == null || !getEconomyManager().hasAccount(target)) {
-                                        MessageManager.sendTranslatedMsgs(player, incorrectPlayerNameMessageList);
-                                        return false;
-                                    }
-                                    MessageManager.sendTranslatedMsgs(player, checkTheOtherPlayerMoneyMessageList
-                                            , "%name_of_player%", target.getName()
-                                            , "%player_money%", df.format(getEconomyManager().getBalance(target)));
-                                    break;
-                                default:
-                                    MessageManager.sendTranslatedMsgs(player, notAvailableCommandMessageList);
-                                    break;
-                            }
-                            break;
-                        case "보내기":
-                            if (args.length != 3) {
-                                MessageManager.sendTranslatedMsgs(player, notAvailableCommandMessageList);
-                                return false;
-                            }
-                            OfflinePlayer recipient = Bukkit.getOfflinePlayerIfCached(args[1]);
-
-                            if (recipient == null || !getEconomyManager().hasAccount(recipient)) {
-                                MessageManager.sendTranslatedMsgs(player, incorrectPlayerNameMessageList);
-                                return false;
-                            }
-                            if (recipient == player) {
-                                MessageManager.sendTranslatedMsgs(player, attemptToDepositToOneselfMessageList);
-                                return false;
-                            }
-                            if (!args[2].matches("[0-9]+")) {
-                                MessageManager.sendTranslatedMsgs(player, invalidSyntaxMessageList);
-                                return false;
-                            }
-                            if (!getEconomyManager().has(player, Double.parseDouble(args[2]))) {
-                                MessageManager.sendTranslatedMsgs(player, moneyShortageMessageList);
-                                return false;
-                            }
-                            if (Long.parseLong(args[2]) < getConfig().getLong("minimum_amount")) {
-                                MessageManager.sendTranslatedMsgs(player, minimumAmountCautionMessageList
-                                        , "%value_of_minimum%", df.format(getConfig().getLong("minimum_amount")));
-                                return false;
-                            }
-                            getEconomyManager().withdrawPlayer(player, Double.parseDouble(args[2]));
-                            getEconomyManager().depositPlayer(recipient, Double.parseDouble(args[2]));
-
-                            MessageManager.sendTranslatedMsgs(player, transactionConfirmToSenderMessageList
-                                    , "%name_of_recipient%", recipient.getName()
-                                    , "%sent_money%", df.format(Long.parseLong(args[2]))
-                                    , "%sender_money_after_transaction%", df.format(getEconomyManager().getBalance(player)));
-
-                            if (recipient.isOnline()) {
-                                Player onlineRecipient = recipient.getPlayer();
-                                assert onlineRecipient != null;
-                                MessageManager.sendTranslatedMsgs(onlineRecipient, transactionConfirmToRecipientMessageList
-                                        , "%name_of_sender%", player.getName()
-                                        , "%received_money%", df.format(Long.parseLong(args[2]))
-                                        , "%recipient_money_after_transaction%", df.format(getEconomyManager().getBalance(recipient)));
-                            }
-                            break;
-                        case "지급":
-                        case "차감":
-                        case "설정":
-                            if (!player.hasPermission("ucon.manage")) {
-                                MessageManager.sendTranslatedMsgs(player, notAvailableCommandMessageList);
-                                return false;
-                            }
-                            if (args.length != 3) {
-                                MessageManager.sendTranslatedMsgs(player, notAvailableCommandMessageList);
-                                return false;
-                            }
-                            OfflinePlayer target = Bukkit.getOfflinePlayerIfCached(args[1]);
-
-                            if (target == null || !getEconomyManager().hasAccount(target)) {
-                                MessageManager.sendTranslatedMsgs(player, incorrectPlayerNameMessageList);
-                                return false;
-                            }
-                            if (!args[2].matches("[0-9]+")) {
-                                MessageManager.sendTranslatedMsgs(player, invalidSyntaxMessageList);
-                                return false;
-                            }
-                            if (args[0].equalsIgnoreCase("지급")) {
-                                getEconomyManager().depositPlayer(target, Double.parseDouble(args[2]));
-
-                                MessageManager.sendTranslatedMsgs(player, increasePlayerMoneyMessageList
-                                        , "%name_of_player%", target.getName()
-                                        , "%increased_money%", df.format(Long.parseLong(args[2])));
-                                return false;
-                            }
-                            if (args[0].equalsIgnoreCase("차감")) {
-                                getEconomyManager().withdrawPlayer(target, Double.parseDouble(args[2]));
-
-                                if (getEconomyManager().getBalance(target) < 0) {
-                                    getEconomyManager().depositPlayer(target, getEconomyManager().getBalance(target) * -1);
-                                }
-                                MessageManager.sendTranslatedMsgs(player, decreasePlayerMoneyMessageList
-                                        , "%name_of_player%", target.getName()
-                                        , "%decreased_money%", df.format(Long.parseLong(args[2])));
-                                return false;
-                            }
-                            if (args[0].equalsIgnoreCase("설정")) {
-                                getEconomyManager().withdrawPlayer(target, getEconomyManager().getBalance(target));
-                                getEconomyManager().depositPlayer(target, Double.parseDouble(args[2]));
-
-                                MessageManager.sendTranslatedMsgs(player, setPlayerMoneyMessageList
-                                        , "%name_of_player%", target.getName()
-                                        , "%set_money%", df.format(Long.parseLong(args[2])));
-                                return false;
-                            }
-                            break;
-                        default:
-                            MessageManager.sendTranslatedMsgs(player, notAvailableCommandMessageList);
-                            break;
-                    }
-                } else {
-                    if (player.hasPermission("ucon.manage")) {
-                        MessageManager.sendTranslatedMsgs(player, opCommandGuideMessageList);
-                    } else {
-                        MessageManager.sendTranslatedMsgs(player, commandGuideMessageList);
-                    }
-                }
-                return false;
-            }
-            if (command.getName().equalsIgnoreCase("uconomy") && args[0].equalsIgnoreCase("reload") && player.hasPermission("ucon.reload")) {
-                reloadConfig();
-                MoneyManager.save();
-                MessageManager.reload();
-                getMessages();
-                MessageManager.sendTranslatedMsgs(player, reloadMessageList);
-            }
-            return false;
-        }
-        return false;
-    }
-
-    public void getMessages() {
-        try {
-            reloadMessageList = MessageManager.get().getStringList("reload_message");
-            commandGuideMessageList = MessageManager.get().getStringList("money_command_guide");
-            opCommandGuideMessageList = MessageManager.get().getStringList("money_command_guide_for_op");
-            notAvailableCommandMessageList = MessageManager.get().getStringList("not_available_command");
-            incorrectPlayerNameMessageList = MessageManager.get().getStringList("incorrect_player_name");
-            invalidSyntaxMessageList = MessageManager.get().getStringList("invalid_syntax");
-            moneyShortageMessageList = MessageManager.get().getStringList("money_shortage");
-            attemptToDepositToOneselfMessageList = MessageManager.get().getStringList("attempt_to_deposit_to_oneself");
-            checkMyMoneyMessageList = MessageManager.get().getStringList("check_my_money");
-            checkTheOtherPlayerMoneyMessageList = MessageManager.get().getStringList("check_the_other_player_money");
-            transactionConfirmToSenderMessageList = MessageManager.get().getStringList("transaction_confirm_to_sender");
-            transactionConfirmToRecipientMessageList = MessageManager.get().getStringList("transaction_confirm_to_recipient");
-            minimumAmountCautionMessageList = MessageManager.get().getStringList("minimum_amount_caution");
-            increasePlayerMoneyMessageList = MessageManager.get().getStringList("increase_player_money");
-            decreasePlayerMoneyMessageList = MessageManager.get().getStringList("decrease_player_money");
-            setPlayerMoneyMessageList = MessageManager.get().getStringList("set_player_money");
-        } catch (NullPointerException e) {
-            e.printStackTrace();
-            getLogger().info("messages.yml에서 메시지를 불러오는 도중 문제가 발생했습니다.");
-        }
     }
 }

--- a/src/main/java/net/teamuni/economy/Uconomy.java
+++ b/src/main/java/net/teamuni/economy/Uconomy.java
@@ -6,6 +6,7 @@ import net.teamuni.economy.command.CommandTabCompleter;
 import net.teamuni.economy.command.UconomyCmd;
 import net.teamuni.economy.config.MessageManager;
 import net.teamuni.economy.data.MoneyManager;
+import net.teamuni.economy.data.PlayerDataManager;
 import net.teamuni.economy.database.MySQLDatabase;
 import net.teamuni.economy.event.JoinEvent;
 import net.teamuni.economy.hooks.HookIntoVault;
@@ -24,6 +25,7 @@ public final class Uconomy extends JavaPlugin {
     private MessageManager messageManager;
     private MoneyManager moneyManager;
     private MySQLDatabase database;
+    private PlayerDataManager playerDataManager;
     private boolean isMySQLUse = false;
 
     @Override
@@ -47,6 +49,8 @@ public final class Uconomy extends JavaPlugin {
                 getLogger().log(Level.SEVERE, "데이터베이스 연결에 실패하였습니다.", e);
                 this.database = null;
             }
+            this.playerDataManager = new PlayerDataManager(this);
+            Bukkit.getPluginManager().registerEvents(this.playerDataManager, this);
         }
         Bukkit.getPluginManager().registerEvents(new JoinEvent(this), this);
         getCommand("돈").setExecutor(new UconomyCmd(this));
@@ -66,6 +70,9 @@ public final class Uconomy extends JavaPlugin {
     public void onDisable() {
         this.moneyManager.save();
         this.hookIntoVault.unhook();
+        if (isMySQLUse) {
+            this.playerDataManager.removeAll();
+        }
     }
 
     private boolean setupEconomy() {

--- a/src/main/java/net/teamuni/economy/command/CommandTabCompleter.java
+++ b/src/main/java/net/teamuni/economy/command/CommandTabCompleter.java
@@ -1,4 +1,4 @@
-package net.teamuni.economy;
+package net.teamuni.economy.command;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -18,59 +18,59 @@ public class CommandTabCompleter implements TabCompleter {
         Player player = (Player) sender;
 
         if (command.getName().equalsIgnoreCase("돈")) {
-            List<String> tabComleteMessage = new ArrayList<>();
+            List<String> tabCompleteMessage = new ArrayList<>();
 
             if (args.length == 1) {
                 if (player.hasPermission("ucon.manage")) {
-                    tabComleteMessage.add("확인");
-                    tabComleteMessage.add("보내기");
-                    tabComleteMessage.add("지급");
-                    tabComleteMessage.add("차감");
-                    tabComleteMessage.add("설정");
+                    tabCompleteMessage.add("확인");
+                    tabCompleteMessage.add("보내기");
+                    tabCompleteMessage.add("지급");
+                    tabCompleteMessage.add("차감");
+                    tabCompleteMessage.add("설정");
                 } else {
-                    tabComleteMessage.add("확인");
-                    tabComleteMessage.add("보내기");
+                    tabCompleteMessage.add("확인");
+                    tabCompleteMessage.add("보내기");
                 }
-                return tabComleteMessage;
+                return tabCompleteMessage;
 
             } else if (args[0].equalsIgnoreCase("확인") && player.hasPermission("ucon.manage")) {
                 if (args.length == 2) {
                     for (Player onlinePlayers : Bukkit.getOnlinePlayers()) {
-                        tabComleteMessage.add(onlinePlayers.getName());
+                        tabCompleteMessage.add(onlinePlayers.getName());
                     }
                 }
-                return tabComleteMessage;
+                return tabCompleteMessage;
 
             } else if (args[0].equalsIgnoreCase("보내기")) {
                 if (args.length == 2) {
                     for (Player onlinePlayers : Bukkit.getOnlinePlayers()) {
-                        tabComleteMessage.add(onlinePlayers.getName());
+                        tabCompleteMessage.add(onlinePlayers.getName());
                     }
                 } else if (args.length == 3) {
-                    tabComleteMessage.add("금액");
+                    tabCompleteMessage.add("금액");
                 }
-                return tabComleteMessage;
+                return tabCompleteMessage;
 
             } else if (args[0].equalsIgnoreCase("지급") || args[0].equalsIgnoreCase("차감") || args[0].equalsIgnoreCase("설정")) {
                 if (player.hasPermission("ucon.manage")) {
                     if (args.length == 2) {
                         for (Player onlinePlayers : Bukkit.getOnlinePlayers()) {
-                            tabComleteMessage.add(onlinePlayers.getName());
+                            tabCompleteMessage.add(onlinePlayers.getName());
                         }
                     } else if (args.length == 3) {
-                        tabComleteMessage.add("금액");
+                        tabCompleteMessage.add("금액");
                     }
                 }
-                return tabComleteMessage;
+                return tabCompleteMessage;
             }
 
         } else if (command.getName().equalsIgnoreCase("uconomy")) {
-            List<String> tabComleteMessage = new ArrayList<>();
+            List<String> tabCompleteMessage = new ArrayList<>();
 
             if (args.length == 1) {
-                tabComleteMessage.add("reload");
+                tabCompleteMessage.add("reload");
             }
-            return tabComleteMessage;
+            return tabCompleteMessage;
         }
         return null;
     }

--- a/src/main/java/net/teamuni/economy/command/UconomyCmd.java
+++ b/src/main/java/net/teamuni/economy/command/UconomyCmd.java
@@ -27,15 +27,15 @@ public class UconomyCmd implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
         if (sender instanceof Player player) {
-
             if (command.getName().equalsIgnoreCase("돈")) {
                 if (args.length > 0) {
                     switch (args[0]) {
                         case "확인":
                             switch (args.length) {
-                                case 1 -> main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("check_my_money")
-                                        , "%name_of_player%", player.getName()
-                                        , "%player_money%", df.format(main.getEconomyManager().getBalance(player)));
+                                case 1 ->
+                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("check_my_money")
+                                                , "%name_of_player%", player.getName()
+                                                , "%player_money%", df.format(main.getEconomyManager().getBalance(player)));
                                 case 2 -> {
                                     if (!player.hasPermission("ucon.manage")) {
                                         main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
@@ -50,7 +50,8 @@ public class UconomyCmd implements CommandExecutor {
                                             , "%name_of_player%", target.getName()
                                             , "%player_money%", df.format(main.getEconomyManager().getBalance(target)));
                                 }
-                                default -> main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                default ->
+                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
                             }
                             break;
                         case "보내기":
@@ -98,9 +99,7 @@ public class UconomyCmd implements CommandExecutor {
                                         , "%recipient_money_after_transaction%", df.format(main.getEconomyManager().getBalance(recipient)));
                             }
                             break;
-                        case "지급":
-                        case "차감":
-                        case "설정":
+                        case "지급", "차감", "설정":
                             if (!player.hasPermission("ucon.manage")) {
                                 main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
                                 return false;

--- a/src/main/java/net/teamuni/economy/command/UconomyCmd.java
+++ b/src/main/java/net/teamuni/economy/command/UconomyCmd.java
@@ -1,0 +1,184 @@
+package net.teamuni.economy.command;
+
+import net.teamuni.economy.Uconomy;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.text.DecimalFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class UconomyCmd implements CommandExecutor {
+    private final Map<String, List<String>> messageListMap = new HashMap<>();
+    private final Uconomy main;
+    private final DecimalFormat df = new DecimalFormat("###,###");
+    public UconomyCmd(Uconomy instance) {
+        this.main = instance;
+        getMessages();
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (sender instanceof Player player) {
+
+            if (command.getName().equalsIgnoreCase("돈")) {
+                if (args.length > 0) {
+                    switch (args[0]) {
+                        case "확인":
+                            switch (args.length) {
+                                case 1 -> main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("check_my_money")
+                                        , "%name_of_player%", player.getName()
+                                        , "%player_money%", df.format(main.getEconomyManager().getBalance(player)));
+                                case 2 -> {
+                                    if (!player.hasPermission("ucon.manage")) {
+                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                        return false;
+                                    }
+                                    OfflinePlayer target = Bukkit.getOfflinePlayerIfCached(args[1]);
+                                    if (target == null || !main.getEconomyManager().hasAccount(target)) {
+                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                        return false;
+                                    }
+                                    main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("check_the_other_player_money")
+                                            , "%name_of_player%", target.getName()
+                                            , "%player_money%", df.format(main.getEconomyManager().getBalance(target)));
+                                }
+                                default -> main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                            }
+                            break;
+                        case "보내기":
+                            if (args.length != 3) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                return false;
+                            }
+                            OfflinePlayer recipient = Bukkit.getOfflinePlayerIfCached(args[1]);
+
+                            if (recipient == null || !main.getEconomyManager().hasAccount(recipient)) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                return false;
+                            }
+                            if (recipient == player) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("attempt_to_deposit_to_oneself"));
+                                return false;
+                            }
+                            if (!args[2].matches("[0-9]+")) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("invalid_syntax"));
+                                return false;
+                            }
+                            if (!main.getEconomyManager().has(player, Double.parseDouble(args[2]))) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("money_shortage"));
+                                return false;
+                            }
+                            if (Long.parseLong(args[2]) < main.getConfig().getLong("minimum_amount")) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("minimum_amount_caution")
+                                        , "%value_of_minimum%", df.format(main.getConfig().getLong("minimum_amount")));
+                                return false;
+                            }
+                            main.getEconomyManager().withdrawPlayer(player, Double.parseDouble(args[2]));
+                            main.getEconomyManager().depositPlayer(recipient, Double.parseDouble(args[2]));
+
+                            main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("transaction_confirm_to_sender")
+                                    , "%name_of_recipient%", recipient.getName()
+                                    , "%sent_money%", df.format(Long.parseLong(args[2]))
+                                    , "%sender_money_after_transaction%", df.format(main.getEconomyManager().getBalance(player)));
+
+                            if (recipient.isOnline()) {
+                                Player onlineRecipient = recipient.getPlayer();
+                                assert onlineRecipient != null;
+                                main.getMessageManager().sendTranslatedMsgs(onlineRecipient, this.messageListMap.get("transaction_confirm_to_recipient")
+                                        , "%name_of_sender%", player.getName()
+                                        , "%received_money%", df.format(Long.parseLong(args[2]))
+                                        , "%recipient_money_after_transaction%", df.format(main.getEconomyManager().getBalance(recipient)));
+                            }
+                            break;
+                        case "지급":
+                        case "차감":
+                        case "설정":
+                            if (!player.hasPermission("ucon.manage")) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                return false;
+                            }
+                            if (args.length != 3) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                return false;
+                            }
+                            OfflinePlayer target = Bukkit.getOfflinePlayerIfCached(args[1]);
+
+                            if (target == null || !main.getEconomyManager().hasAccount(target)) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                return false;
+                            }
+                            if (!args[2].matches("[0-9]+")) {
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("invalid_syntax"));
+                                return false;
+                            }
+                            if (args[0].equalsIgnoreCase("지급")) {
+                                main.getEconomyManager().depositPlayer(target, Double.parseDouble(args[2]));
+
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("increase_player_money")
+                                        , "%name_of_player%", target.getName()
+                                        , "%increased_money%", df.format(Long.parseLong(args[2])));
+                                return false;
+                            }
+                            if (args[0].equalsIgnoreCase("차감")) {
+                                main.getEconomyManager().withdrawPlayer(target, Double.parseDouble(args[2]));
+
+                                if (main.getEconomyManager().getBalance(target) < 0) {
+                                    main.getEconomyManager().depositPlayer(target, main.getEconomyManager().getBalance(target) * -1);
+                                }
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("decrease_player_money")
+                                        , "%name_of_player%", target.getName()
+                                        , "%decreased_money%", df.format(Long.parseLong(args[2])));
+                                return false;
+                            }
+                            if (args[0].equalsIgnoreCase("설정")) {
+                                main.getEconomyManager().withdrawPlayer(target, main.getEconomyManager().getBalance(target));
+                                main.getEconomyManager().depositPlayer(target, Double.parseDouble(args[2]));
+
+                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("set_player_money")
+                                        , "%name_of_player%", target.getName()
+                                        , "%set_money%", df.format(Long.parseLong(args[2])));
+                                return false;
+                            }
+                            break;
+                        default:
+                            main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                            break;
+                    }
+                } else {
+                    if (player.hasPermission("ucon.manage")) {
+                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("money_command_guide_for_op"));
+                    } else {
+                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("money_command_guide"));
+                    }
+                }
+                return false;
+            }
+            if (command.getName().equalsIgnoreCase("uconomy") && args[0].equalsIgnoreCase("reload") && player.hasPermission("ucon.reload")) {
+                main.reloadConfig();
+                main.getMoneyManager().save();
+                main.getMessageManager().reload();
+                getMessages();
+                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("reload_message"));
+            }
+            return false;
+        }
+        return false;
+    }
+
+    public void getMessages() {
+        ConfigurationSection section = main.getMessageManager().get().getConfigurationSection("Messages");
+        if (section == null) return;
+        for (String key : section.getKeys(false)) {
+            List<String> messages = section.getStringList(key);
+            this.messageListMap.put(key, messages);
+        }
+    }
+}

--- a/src/main/java/net/teamuni/economy/config/MessageManager.java
+++ b/src/main/java/net/teamuni/economy/config/MessageManager.java
@@ -13,36 +13,44 @@ import java.io.IOException;
 import java.util.List;
 
 public class MessageManager {
-    private static final Uconomy main = Uconomy.getPlugin(Uconomy.class);
-    private static File file;
-    private static FileConfiguration commandsFile;
+    private final Uconomy main;
+    private File file = null;
+    private FileConfiguration messagesFile = null;
+    public MessageManager(Uconomy instance) {
+        this.main = instance;
+    }
 
-    public static void createMessagesYml() {
-        file = new File(main.getDataFolder(), "messages.yml");
-
+    public void createMessagesYml() {
+        if (this.file == null) {
+            this.file = new File(main.getDataFolder(), "messages.yml");
+        }
         if (!file.exists()) {
             main.saveResource("messages.yml", false);
         }
-        commandsFile = YamlConfiguration.loadConfiguration(file);
+        this.messagesFile = YamlConfiguration.loadConfiguration(file);
     }
 
-    public static FileConfiguration get() {
-        return commandsFile;
+    public FileConfiguration get() {
+        return messagesFile;
     }
 
-    public static void save() {
+    public void save() {
+        if (this.file == null || this.messagesFile == null) return;
         try {
-            commandsFile.save(file);
+            this.messagesFile.save(file);
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
-    public static void reload() {
-        commandsFile = YamlConfiguration.loadConfiguration(file);
+    public void reload() {
+        if (this.file == null) {
+            this.file = new File(main.getDataFolder(), "messages.yml");
+        }
+        this.messagesFile = YamlConfiguration.loadConfiguration(file);
     }
 
-    public static void sendTranslatedMsgs(Player player, List<String> msgList) {
+    public void sendTranslatedMsgs(Player player, List<String> msgList) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {
@@ -55,7 +63,7 @@ public class MessageManager {
         }
     }
 
-    public static void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg) {
+    public void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {
@@ -72,7 +80,7 @@ public class MessageManager {
         }
     }
 
-    public static void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2) {
+    public void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {
@@ -91,7 +99,7 @@ public class MessageManager {
         }
     }
 
-    public static void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2, String msg3, String transMsg3) {
+    public void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2, String msg3, String transMsg3) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {

--- a/src/main/java/net/teamuni/economy/data/EconomyManager.java
+++ b/src/main/java/net/teamuni/economy/data/EconomyManager.java
@@ -224,14 +224,12 @@ public class EconomyManager implements Economy {
         }
         double depositedMoney = getBalance(player) + amount;
         if (main.isMySQLUse()) {
-            Bukkit.getLogger().info("isMySQLUse = true");
             try {
                 main.getDatabase().updatePlayerStats(new PlayerData(player.getUniqueId().toString(), (long) depositedMoney));
             } catch (SQLException e) {
                 throw new RuntimeException(e);
             }
         } else {
-            Bukkit.getLogger().info("isMySQLUse = false");
             main.getMoneyManager().get().set("player." + player.getUniqueId(), (long) depositedMoney);
         }
         return new EconomyResponse(amount, depositedMoney, EconomyResponse.ResponseType.SUCCESS, "");

--- a/src/main/java/net/teamuni/economy/data/EconomyManager.java
+++ b/src/main/java/net/teamuni/economy/data/EconomyManager.java
@@ -2,16 +2,19 @@ package net.teamuni.economy.data;
 
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
-import net.teamuni.economy.data.MoneyManager;
+import net.teamuni.economy.Uconomy;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import java.io.File;
 import java.text.DecimalFormat;
 import java.util.*;
 
 public class EconomyManager implements Economy {
+    private final Uconomy main;
+    public EconomyManager(Uconomy instance) {
+        this.main = instance;
+    }
 
     @Override
     public boolean isEnabled() {
@@ -69,7 +72,7 @@ public class EconomyManager implements Economy {
 
     @Override
     public boolean hasAccount(OfflinePlayer player) {
-        return MoneyManager.get().getConfigurationSection("player").isSet(player.getUniqueId().toString());
+        return main.getMoneyManager().get().getConfigurationSection("player").isSet(player.getUniqueId().toString());
     }
 
     @Deprecated
@@ -79,7 +82,7 @@ public class EconomyManager implements Economy {
 
     @Override
     public boolean hasAccount(OfflinePlayer player, String worldName) {
-        return MoneyManager.get().getConfigurationSection("player").isSet(player.getUniqueId().toString());
+        return main.getMoneyManager().get().getConfigurationSection("player").isSet(player.getUniqueId().toString());
     }
 
     @Deprecated
@@ -87,13 +90,13 @@ public class EconomyManager implements Economy {
         Player player = Bukkit.getPlayer(playerName);
         assert player != null;
         String playerUuid = player.getUniqueId().toString();
-        return MoneyManager.get().getLong("player." + playerUuid);
+        return main.getMoneyManager().get().getLong("player." + playerUuid);
     }
 
     @Override
     public double getBalance(OfflinePlayer player) {
         String playerUuid = player.getUniqueId().toString();
-        return MoneyManager.get().getLong("player." + playerUuid);
+        return main.getMoneyManager().get().getLong("player." + playerUuid);
     }
 
     @Deprecated
@@ -101,13 +104,13 @@ public class EconomyManager implements Economy {
         Player player = Bukkit.getPlayer(playerName);
         assert player != null;
         String playerUuid = player.getUniqueId().toString();
-        return MoneyManager.get().getLong("player." + playerUuid);
+        return main.getMoneyManager().get().getLong("player." + playerUuid);
     }
 
     @Override
     public double getBalance(OfflinePlayer player, String world) {
         String playerUuid = player.getUniqueId().toString();
-        return MoneyManager.get().getLong("player." + playerUuid);
+        return main.getMoneyManager().get().getLong("player." + playerUuid);
     }
 
     @Deprecated
@@ -141,7 +144,7 @@ public class EconomyManager implements Economy {
             return new EconomyResponse(0, 0, EconomyResponse.ResponseType.FAILURE, "The player doesn't has an Account!");
         }
         double withdrawedMoney = getBalance(player) - amount;
-        MoneyManager.get().set("player." + player.getUniqueId(), (long) withdrawedMoney);
+        main.getMoneyManager().get().set("player." + player.getUniqueId(), (long) withdrawedMoney);
 
         return new EconomyResponse(amount, withdrawedMoney, EconomyResponse.ResponseType.SUCCESS, "");
     }
@@ -157,7 +160,7 @@ public class EconomyManager implements Economy {
             return new EconomyResponse(0, 0, EconomyResponse.ResponseType.FAILURE, "The player doesn't has an Account!");
         }
         double withdrawedMoney = getBalance(player) - amount;
-        MoneyManager.get().set("player." + player.getUniqueId(), (long) withdrawedMoney);
+        main.getMoneyManager().get().set("player." + player.getUniqueId(), (long) withdrawedMoney);
 
         return new EconomyResponse(amount, withdrawedMoney, EconomyResponse.ResponseType.SUCCESS, "");
     }
@@ -173,7 +176,7 @@ public class EconomyManager implements Economy {
             return new EconomyResponse(0, 0, EconomyResponse.ResponseType.FAILURE, "The player doesn't has an Account!");
         }
         double depositedMoney = getBalance(player) + amount;
-        MoneyManager.get().set("player." + player.getUniqueId(), (long) depositedMoney);
+        main.getMoneyManager().get().set("player." + player.getUniqueId(), (long) depositedMoney);
 
         return new EconomyResponse(amount, depositedMoney, EconomyResponse.ResponseType.SUCCESS, "");
     }
@@ -189,7 +192,7 @@ public class EconomyManager implements Economy {
             return new EconomyResponse(0, 0, EconomyResponse.ResponseType.FAILURE, "The player doesn't has an Account!");
         }
         double depositedMoney = getBalance(player) + amount;
-        MoneyManager.get().set("player." + player.getUniqueId(), (long) depositedMoney);
+        main.getMoneyManager().get().set("player." + player.getUniqueId(), (long) depositedMoney);
 
         return new EconomyResponse(amount, depositedMoney, EconomyResponse.ResponseType.SUCCESS, "");
     }
@@ -261,7 +264,7 @@ public class EconomyManager implements Economy {
 
     @Override
     public boolean createPlayerAccount(OfflinePlayer player) {
-        MoneyManager.get().set("player." + player.getUniqueId(), 0);
+        main.getMoneyManager().get().set("player." + player.getUniqueId(), 0);
         return false;
     }
 
@@ -272,7 +275,7 @@ public class EconomyManager implements Economy {
 
     @Override
     public boolean createPlayerAccount(OfflinePlayer player, String worldName) {
-        MoneyManager.get().set("player." + player.getUniqueId(), 0);
+        main.getMoneyManager().get().set("player." + player.getUniqueId(), 0);
         return false;
     }
 }

--- a/src/main/java/net/teamuni/economy/data/MoneyManager.java
+++ b/src/main/java/net/teamuni/economy/data/MoneyManager.java
@@ -8,11 +8,13 @@ import java.io.File;
 import java.io.IOException;
 
 public class MoneyManager {
-    private static final Uconomy main = Uconomy.getPlugin(Uconomy.class);
-    private static File file;
-    private static FileConfiguration commandsFile;
-
-    public static void createMoneyDataYml() {
+    private final Uconomy main;
+    private File file = null;
+    private FileConfiguration commandsFile = null;
+    public MoneyManager(Uconomy instance) {
+        this.main = instance;
+    }
+    public void createMoneyDataYml() {
         file = new File(main.getDataFolder(), "moneydata.yml");
 
         if (!file.exists()) {
@@ -21,11 +23,11 @@ public class MoneyManager {
         commandsFile = YamlConfiguration.loadConfiguration(file);
     }
 
-    public static FileConfiguration get() {
+    public FileConfiguration get() {
         return commandsFile;
     }
 
-    public static void save() {
+    public void save() {
         try {
             commandsFile.save(file);
         } catch (IOException e) {
@@ -33,7 +35,7 @@ public class MoneyManager {
         }
     }
 
-    public static void reload() {
+    public void reload() {
         commandsFile = YamlConfiguration.loadConfiguration(file);
     }
 }

--- a/src/main/java/net/teamuni/economy/data/MoneyManager.java
+++ b/src/main/java/net/teamuni/economy/data/MoneyManager.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 public class MoneyManager {
     private final Uconomy main;
     private File file = null;
-    private FileConfiguration commandsFile = null;
+    private FileConfiguration moneyDataFile = null;
     public MoneyManager(Uconomy instance) {
         this.main = instance;
     }
@@ -20,22 +20,26 @@ public class MoneyManager {
         if (!file.exists()) {
             main.saveResource("moneydata.yml", false);
         }
-        commandsFile = YamlConfiguration.loadConfiguration(file);
+        moneyDataFile = YamlConfiguration.loadConfiguration(file);
     }
 
     public FileConfiguration get() {
-        return commandsFile;
+        return moneyDataFile;
     }
 
     public void save() {
+        if (this.file == null || this.moneyDataFile == null) return;
         try {
-            commandsFile.save(file);
+            moneyDataFile.save(file);
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
     public void reload() {
-        commandsFile = YamlConfiguration.loadConfiguration(file);
+        if (this.file == null) {
+            this.file = new File(main.getDataFolder(), "moneydata.yml");
+        }
+        moneyDataFile = YamlConfiguration.loadConfiguration(file);
     }
 }

--- a/src/main/java/net/teamuni/economy/data/PlayerData.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerData.java
@@ -1,0 +1,4 @@
+package net.teamuni.economy.data;
+
+public record PlayerData(String uuid, long money) {
+}

--- a/src/main/java/net/teamuni/economy/data/PlayerData.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerData.java
@@ -1,4 +1,17 @@
 package net.teamuni.economy.data;
 
-public record PlayerData(String uuid, long money) {
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PlayerData {
+    private final String uuid;
+    private long money;
+    public void afterDeposit(long depositedMoney) {
+        this.money = depositedMoney;
+    }
+    public void afterWithdraw(long withDrewMoney) {
+        this.money = withDrewMoney;
+    }
 }

--- a/src/main/java/net/teamuni/economy/data/PlayerDataManager.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerDataManager.java
@@ -1,0 +1,76 @@
+package net.teamuni.economy.data;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalListeners;
+import net.teamuni.economy.Uconomy;
+import net.teamuni.economy.database.MySQLDatabase;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
+import java.util.concurrent.Executors;
+
+public class PlayerDataManager implements Listener {
+    private final Uconomy main;
+    private final LoadingCache<UUID, PlayerData> cache;
+
+    public PlayerDataManager(Uconomy instance) {
+        this.main = instance;
+        this.cache = CacheBuilder.newBuilder().removalListener(
+                        RemovalListeners.asynchronous((RemovalListener<UUID, PlayerData>) notify -> {
+                            PlayerData data = notify.getValue();
+                            if (data == null) {
+                                return;
+                            }
+                            MySQLDatabase database = instance.getDatabase();
+                            if (database == null) {
+                                return;
+                            }
+                            database.updatePlayerStats(data);
+                        }, Executors.newFixedThreadPool(5)))
+                .build(new CacheLoader<>() {
+
+                    @Override
+                    public @NotNull PlayerData load(@NotNull UUID uuid) {
+                        MySQLDatabase database = instance.getDatabase();
+                        if (database == null) {
+                            return new PlayerData(uuid.toString(), 0);
+                        }
+                        return database.loadPlayerStats(uuid);
+                    }
+                });
+    }
+
+    @EventHandler
+    public void onQuit(PlayerQuitEvent event) {
+        remove(event.getPlayer());
+    }
+
+    public void remove(Player player) {
+        this.cache.invalidate(player.getUniqueId());
+        this.cache.cleanUp();
+    }
+
+    public void removeAll() {
+        this.cache.invalidateAll();
+        this.cache.cleanUp();
+    }
+
+    @NotNull
+    public PlayerData getCache(@NotNull UUID uuid) {
+        return this.cache.getUnchecked(uuid);
+    }
+
+    @Nullable
+    public PlayerData getCacheIfPresent(@NotNull UUID uuid) {
+        return this.cache.getIfPresent(uuid);
+    }
+}
+

--- a/src/main/java/net/teamuni/economy/data/PlayerDataManager.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerDataManager.java
@@ -18,11 +18,9 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 
 public class PlayerDataManager implements Listener {
-    private final Uconomy main;
     private final LoadingCache<UUID, PlayerData> cache;
 
     public PlayerDataManager(Uconomy instance) {
-        this.main = instance;
         this.cache = CacheBuilder.newBuilder().removalListener(
                         RemovalListeners.asynchronous((RemovalListener<UUID, PlayerData>) notify -> {
                             PlayerData data = notify.getValue();

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -52,8 +52,6 @@ public class MySQLDatabase {
             if (resultSet.next()) {
                 return new PlayerData(uuid, resultSet.getLong(2));
             }
-        } catch (SQLException e) {
-            e.printStackTrace();
         }
         return null;
     }
@@ -68,8 +66,6 @@ public class MySQLDatabase {
             if (resultSet.next()) {
                 return resultSet.getLong(2);
             }
-        } catch (SQLException e) {
-            e.printStackTrace();
         }
         return 0;
     }
@@ -82,8 +78,6 @@ public class MySQLDatabase {
 
         try (connection; statement) {
             statement.executeUpdate();
-        } catch (SQLException e) {
-            e.printStackTrace();
         }
     }
 
@@ -95,8 +89,6 @@ public class MySQLDatabase {
 
         try (connection; statement) {
             statement.executeUpdate();
-        } catch (SQLException e) {
-            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -1,0 +1,102 @@
+package net.teamuni.economy.database;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import net.teamuni.economy.data.PlayerData;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class MySQLDatabase {
+    private final HikariDataSource sql;
+
+    public MySQLDatabase(String host, int port, String database, String parameters, String user, String password) {
+        HikariConfig config = new HikariConfig();
+        config.setUsername(user);
+        config.setPassword(password);
+        var sb = new StringBuilder("jdbc:mysql://")
+                .append(host).append(":").append(port).append("/").append(database);
+        if (!parameters.isEmpty()) {
+            sb.append(parameters);
+        }
+        config.setJdbcUrl(sb.toString());
+
+        this.sql = new HikariDataSource(config);
+
+        try {
+            initTable();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void initTable() throws SQLException {
+        try (Connection connection = this.sql.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                String sql = "CREATE TABLE IF NOT EXISTS uc_stats(uuid varchar(36) primary key, money BIGINT)";
+                statement.execute(sql);
+            }
+        }
+    }
+
+    public PlayerData findPlayerStatsByUUID(String uuid) throws SQLException {
+        Connection connection = this.sql.getConnection();
+        PreparedStatement statement = connection.prepareStatement("SELECT * FROM uc_stats WHERE uuid = ?");
+        statement.setString(1, uuid);
+        ResultSet resultSet = statement.executeQuery();
+
+        try (connection; statement; resultSet) {
+            if (resultSet.next()) {
+                return new PlayerData(uuid, resultSet.getLong(2));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public long getPlayerMoney(String uuid) throws SQLException {
+        Connection connection = this.sql.getConnection();
+        PreparedStatement statement = connection.prepareStatement("SELECT * FROM uc_stats WHERE uuid = ?");
+        statement.setString(1, uuid);
+        ResultSet resultSet = statement.executeQuery();
+
+        try (connection; statement; resultSet) {
+            if (resultSet.next()) {
+                return resultSet.getLong(2);
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return 0;
+    }
+
+    public void createPlayerStats(PlayerData stats) throws SQLException {
+        Connection connection = this.sql.getConnection();
+        PreparedStatement statement = connection.prepareStatement("INSERT INTO uc_stats(uuid, money) VALUES (?, ?)");
+        statement.setString(1, stats.uuid());
+        statement.setLong(2, stats.money());
+
+        try (connection; statement) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void updatePlayerStats(PlayerData stats) throws SQLException {
+        Connection connection = this.sql.getConnection();
+        PreparedStatement statement = connection.prepareStatement("UPDATE uc_stats SET money = ? WHERE uuid = ?");
+        statement.setLong(1, stats.money());
+        statement.setString(2, stats.uuid());
+
+        try (connection; statement) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -46,9 +46,10 @@ public class MySQLDatabase {
     public void updatePlayerStats(PlayerData stats) {
         try {
             Connection connection = this.sql.getConnection();
-            PreparedStatement statement = connection.prepareStatement("UPDATE uc_stats SET money = ? WHERE uuid = ?");
-            statement.setLong(1, stats.getMoney());
-            statement.setString(2, stats.getUuid());
+            PreparedStatement statement = connection.prepareStatement("INSERT INTO uc_stats (uuid, money) VALUE (?, ?) ON DUPLICATE KEY UPDATE money = ?");
+            statement.setString(1, stats.getUuid());
+            statement.setLong(2, stats.getMoney());
+            statement.setLong(3, stats.getMoney());
 
             try (connection; statement) {
                 statement.executeUpdate();

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -9,14 +9,16 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 public class JoinEvent implements Listener {
+    private final Uconomy main;
+    public JoinEvent(Uconomy instance) {
+        this.main = instance;
+    }
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        String playerUuid = player.getUniqueId().toString();
-
-        if (!Uconomy.getEconomyManager().hasAccount(player)) {
-            Uconomy.getEconomyManager().createPlayerAccount(player);
+        if (!main.getEconomyManager().hasAccount(player)) {
+            main.getEconomyManager().createPlayerAccount(player);
             Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");
         }
     }

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -1,6 +1,7 @@
 package net.teamuni.economy.event;
 
 import net.teamuni.economy.Uconomy;
+import net.teamuni.economy.data.PlayerDataManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -18,7 +19,10 @@ public class JoinEvent implements Listener {
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
-            main.getPlayerDataManager().getCache(player.getUniqueId());
+            PlayerDataManager playerDataManager = main.getPlayerDataManager();
+            if (playerDataManager.getCacheIfPresent(player.getUniqueId()) == null) {
+                playerDataManager.getCache(player.getUniqueId());
+            }
             if (!main.getEconomyManager().hasAccount(player)) {
                 main.getEconomyManager().createPlayerAccount(player);
                 Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -1,7 +1,6 @@
 package net.teamuni.economy.event;
 
 import net.teamuni.economy.Uconomy;
-import net.teamuni.economy.data.PlayerDataManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -19,10 +18,7 @@ public class JoinEvent implements Listener {
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
-            PlayerDataManager playerDataManager = main.getPlayerDataManager();
-            if (playerDataManager.getCacheIfPresent(player.getUniqueId()) == null) {
-                playerDataManager.getCache(player.getUniqueId());
-            }
+            main.getPlayerDataManager().getCache(player.getUniqueId());
             if (!main.getEconomyManager().hasAccount(player)) {
                 main.getEconomyManager().createPlayerAccount(player);
                 Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -17,9 +17,11 @@ public class JoinEvent implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        if (!main.getEconomyManager().hasAccount(player)) {
-            main.getEconomyManager().createPlayerAccount(player);
-            Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");
-        }
+        Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
+            if (!main.getEconomyManager().hasAccount(player)) {
+                main.getEconomyManager().createPlayerAccount(player);
+                Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");
+            }
+        });
     }
 }

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -18,6 +18,7 @@ public class JoinEvent implements Listener {
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
+            main.getPlayerDataManager().getCache(player.getUniqueId());
             if (!main.getEconomyManager().hasAccount(player)) {
                 main.getEconomyManager().createPlayerAccount(player);
                 Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -18,7 +18,9 @@ public class JoinEvent implements Listener {
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         Bukkit.getScheduler().runTaskAsynchronously(main, () -> {
-            main.getPlayerDataManager().getCache(player.getUniqueId());
+            if (main.isMySQLUse()) {
+                main.getPlayerDataManager().getCache(player.getUniqueId());
+            }
             if (!main.getEconomyManager().hasAccount(player)) {
                 main.getEconomyManager().createPlayerAccount(player);
                 Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");

--- a/src/main/java/net/teamuni/economy/hooks/HookIntoVault.java
+++ b/src/main/java/net/teamuni/economy/hooks/HookIntoVault.java
@@ -6,17 +6,20 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.ServicePriority;
 
 public class HookIntoVault {
-    private final Uconomy plugin = Uconomy.getInstance();
     private Economy provider;
+    private final Uconomy main;
+    public HookIntoVault(Uconomy instance) {
+        this.main = instance;
+    }
 
     public void hook() {
-        provider = Uconomy.getEconomyManager();
-        Bukkit.getServicesManager().register(Economy.class, provider, this.plugin, ServicePriority.High);
-        Bukkit.getLogger().info("[Uconomy] Vault is hooked into " + plugin.getName() + " sucessfully!");
+        this.provider = main.getEconomyManager();
+        Bukkit.getServicesManager().register(Economy.class, this.provider, this.main, ServicePriority.High);
+        Bukkit.getLogger().info("[Uconomy] Vault is hooked into " + this.main.getName() + " sucessfully!");
     }
 
     public void unhook() {
         Bukkit.getServicesManager().unregister(Economy.class, this.provider);
-        Bukkit.getLogger().info("[Uconomy] Vault is unhooked from " + plugin.getName() + " sucessfully!");
+        Bukkit.getLogger().info("[Uconomy] Vault is unhooked from " + this.main.getName() + " sucessfully!");
     }
 }

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -2,7 +2,6 @@ package net.teamuni.economy.hooks;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import net.teamuni.economy.Uconomy;
-import net.teamuni.economy.data.MoneyManager;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -10,10 +10,8 @@ import org.jetbrains.annotations.Nullable;
 import java.text.DecimalFormat;
 
 public class UconomyPlaceholders extends PlaceholderExpansion {
-
-    DecimalFormat df = new DecimalFormat("###,###");
-
-    private final Uconomy main = Uconomy.getInstance();
+    private final DecimalFormat df = new DecimalFormat("###,###");
+    private final Uconomy main = Uconomy.getPlugin(Uconomy.class);
 
     @Override
     public @NotNull String getAuthor() {
@@ -38,7 +36,7 @@ public class UconomyPlaceholders extends PlaceholderExpansion {
     @Override
     public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
         if (params.equalsIgnoreCase("balance")) {
-            return df.format(MoneyManager.get().getLong("player." + player.getUniqueId()));
+            return df.format(main.getMoneyManager().get().getLong("player." + player.getUniqueId()));
         }
         if (params.equalsIgnoreCase("minimum_value")) {
             return df.format(main.getConfig().getLong("minimum_amount"));

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -38,8 +38,7 @@ public class UconomyPlaceholders extends PlaceholderExpansion {
         if (params.equalsIgnoreCase("balance")) {
             if (main.isMySQLUse()) {
                 PlayerData cacheIfPresent = main.getPlayerDataManager().getCacheIfPresent(player.getUniqueId());
-                PlayerData cacheUnchecked = main.getPlayerDataManager().getCache(player.getUniqueId());
-                return cacheIfPresent == null ? df.format(cacheUnchecked.getMoney()) : df.format(cacheIfPresent.getMoney());
+                return cacheIfPresent == null ? "0" : df.format(cacheIfPresent.getMoney());
             }
             return df.format(main.getMoneyManager().get().getLong("player." + player.getUniqueId()));
         }

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -2,6 +2,7 @@ package net.teamuni.economy.hooks;
 
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import net.teamuni.economy.Uconomy;
+import net.teamuni.economy.data.PlayerData;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +36,11 @@ public class UconomyPlaceholders extends PlaceholderExpansion {
     @Override
     public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
         if (params.equalsIgnoreCase("balance")) {
+            if (main.isMySQLUse()) {
+                PlayerData cacheIfPresent = main.getPlayerDataManager().getCacheIfPresent(player.getUniqueId());
+                PlayerData cacheUnchecked = main.getPlayerDataManager().getCache(player.getUniqueId());
+                return cacheIfPresent == null ? df.format(cacheUnchecked.getMoney()) : df.format(cacheIfPresent.getMoney());
+            }
             return df.format(main.getMoneyManager().get().getLong("player." + player.getUniqueId()));
         }
         if (params.equalsIgnoreCase("minimum_value")) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,1 +1,12 @@
+# 돈 보내기 기능의 최소 금액
 minimum_amount: 1
+#MySQL 사용 여부
+mysql_use: false
+#MySQL Config
+MySQL:
+  Host: 127.0.0.1
+  Port: 3306
+  Parameters: '?characterEncoding=utf8&autoReconnect=true'
+  Database: uconomy
+  Username: username
+  Password: 'abc123'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,103 +1,103 @@
 # 모든 메시지에는 마인크래프트 색코드를 사용할 수 있습니다.
 # PlaceholderAPI를 지원합니다.
+Messages:
+  money_command_guide: #[/돈] 명령어를 입력하면 출력되는 메시지입니다.
+    - ""
+    - " &a[돈 도움말]"
+    - ""
+    - " &f/돈 &6확인 &f- 자신의 돈을 확인합니다."
+    - " &f/돈 &6보내기 <닉네임> <금액> &f- <닉네임>에게 <금액>만큼의 돈을 보냅니다."
+    - ""
+  money_command_guide_for_op: #OP권한을 가진 상태에서 [/돈] 명령어를 입력하면 출력되는 메시지입니다.
+    - ""
+    - " &a[돈 도움말(OP)]"
+    - ""
+    - " &f/돈 &6확인 &f- 자신의 돈을 확인합니다."
+    - " &f/돈 &6보내기 <닉네임> <금액> &f- <닉네임>에게 <금액>만큼의 돈을 보냅니다."
+    - " &f/돈 &6지급 <닉네임> <금액> &f- <닉네임>에게 <금액>만큼의 돈을 지급합니다. &c(OP)"
+    - " &f/돈 &6차감 <닉네임> <금액> &f- <닉네임>의 돈을 <금액>만큼 차감합니다. &c(OP)"
+    - " &f/돈 &6설정 <닉네임> <금액> &f- <닉네임>의 돈을 <금액>으로 설정합니다. &c(OP)"
+    - ""
+  reload_message: #[/uconomy reload] 명령어를 입력하면 출력되는 메시지입니다.
+    - ""
+    - "&e&lUconomy has been reloaded!"
+    - ""
+  not_available_command: #명령어를 실행할 수 없을 때 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f명령어를 실행할 수 없습니다."
+    - ""
+  incorrect_player_name: #존재하지 않는 플레이어나 오프라인 상태의 플레이어에게 [/돈 보내기, 지급, 차감, 설정] 명령어를 시도했을 때 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f입력하신 플레이어는 존재하지 않는 플레이어입니다."
+    - ""
+  invalid_syntax: #숫자가 들어가야하는 자리에 문자가 들어간 경우 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f숫자가 들어가야 하는 자리에 문자가 들어갈 수 없습니다."
+    - ""
+  money_shortage: #돈이 부족할 때 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f돈이 부족합니다."
+    - ""
+  attempt_to_deposit_to_oneself: #자신에게 돈을 보낼 때 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f자신에게 돈을 보낼 수 없습니다."
+    - ""
 
-money_command_guide: #[/돈] 명령어를 입력하면 출력되는 메시지입니다.
-  - ""
-  - " &a[돈 도움말]"
-  - ""
-  - " &f/돈 &6확인 &f- 자신의 돈을 확인합니다."
-  - " &f/돈 &6보내기 <닉네임> <금액> &f- <닉네임>에게 <금액>만큼의 돈을 보냅니다."
-  - ""
-money_command_guide_for_op: #OP권한을 가진 상태에서 [/돈] 명령어를 입력하면 출력되는 메시지입니다.
-  - ""
-  - " &a[돈 도움말(OP)]"
-  - ""
-  - " &f/돈 &6확인 &f- 자신의 돈을 확인합니다."
-  - " &f/돈 &6보내기 <닉네임> <금액> &f- <닉네임>에게 <금액>만큼의 돈을 보냅니다."
-  - " &f/돈 &6지급 <닉네임> <금액> &f- <닉네임>에게 <금액>만큼의 돈을 지급합니다. &c(OP)"
-  - " &f/돈 &6차감 <닉네임> <금액> &f- <닉네임>의 돈을 <금액>만큼 차감합니다. &c(OP)"
-  - " &f/돈 &6설정 <닉네임> <금액> &f- <닉네임>의 돈을 <금액>으로 설정합니다. &c(OP)"
-  - ""
-reload_message: #[/uconomy reload] 명령어를 입력하면 출력되는 메시지입니다.
-  - ""
-  - "&e&lUconomy has been reloaded!"
-  - ""
-not_available_command: #명령어를 실행할 수 없을 때 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f명령어를 실행할 수 없습니다."
-  - ""
-incorrect_player_name: #존재하지 않는 플레이어나 오프라인 상태의 플레이어에게 [/돈 보내기, 지급, 차감, 설정] 명령어를 시도했을 때 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f입력하신 플레이어는 존재하지 않는 플레이어입니다."
-  - ""
-invalid_syntax: #숫자가 들어가야하는 자리에 문자가 들어간 경우 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f숫자가 들어가야 하는 자리에 문자가 들어갈 수 없습니다."
-  - ""
-money_shortage: #돈이 부족할 때 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f돈이 부족합니다."
-  - ""
-attempt_to_deposit_to_oneself: #자신에게 돈을 보낼 때 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f자신에게 돈을 보낼 수 없습니다."
-  - ""
+    #플레이어의 닉네임 가져오기: %name_of_player%
+    #플레이어의 돈 정보 가져오기: %player_money%
+  check_my_money: #자신의 돈을 확인할 때 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f현재 &d%name_of_player%&f님이 보유하고 있는 돈은 &6%player_money%&f원입니다."
+    - ""
 
-  #플레이어의 닉네임 가져오기: %name_of_player%
-  #플레이어의 돈 정보 가져오기: %player_money%
-check_my_money: #자신의 돈을 확인할 때 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f현재 &d%name_of_player%&f님이 보유하고 있는 돈은 &6%player_money%&f원입니다."
-  - ""
+    #플레이어의 닉네임 가져오기: %name_of_player%
+    #플레이어의 돈 정보 가져오기: %player_money%
+  check_the_other_player_money: #다른 플레이어의 돈을 확인할 때 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f현재 &d%name_of_player%&f님이 보유하고 있는 돈은 &6%player_money%&f원입니다."
+    - ""
 
-  #플레이어의 닉네임 가져오기: %name_of_player%
-  #플레이어의 돈 정보 가져오기: %player_money%
-check_the_other_player_money: #다른 플레이어의 돈을 확인할 때 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f현재 &d%name_of_player%&f님이 보유하고 있는 돈은 &6%player_money%&f원입니다."
-  - ""
+    #돈을 받은 플레이어의 닉네임 가져오기: %name_of_recipient%
+    #보낸 돈의 값 가져오기: %sent_money%
+    #거래 후 돈을 보낸 플레이어의 잔액 가져오기: %sender_money_after_transaction%
+  transaction_confirm_to_sender: #다른 플레이어에게 돈을 보냈을 때 돈을 보낸 플레이어에게 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &d%name_of_recipient%&f님에게 &6%sent_money%&f원을 보냈습니다."
+    - "&e[알림] &f잔액: &6%sender_money_after_transaction%&f원"
+    - ""
 
-  #돈을 받은 플레이어의 닉네임 가져오기: %name_of_recipient%
-  #보낸 돈의 값 가져오기: %sent_money%
-  #거래 후 돈을 보낸 플레이어의 잔액 가져오기: %sender_money_after_transaction%
-transaction_confirm_to_sender: #다른 플레이어에게 돈을 보냈을 때 돈을 보낸 플레이어에게 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &d%name_of_recipient%&f님에게 &6%sent_money%&f원을 보냈습니다."
-  - "&e[알림] &f잔액: &6%sender_money_after_transaction%&f원"
-  - ""
+    #돈을 보낸 플레이어의 닉네임 가져오기: %name_of_sender%
+    #받은 돈의 값 가져오기: %received_money%
+    #거래 후 돈을 받은 플레이어의 잔액 가져오기: %recipient_money_after_transaction%
+  transaction_confirm_to_recipient: #다른 플레이어에게 돈을 보냈을 때 돈을 받은 플레이어에게 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &d%name_of_sender%&f님에게 &6%received_money%&f원을 받았습니다."
+    - "&e[알림] &f잔액: &6%recipient_money_after_transaction%&f원"
+    - ""
 
-  #돈을 보낸 플레이어의 닉네임 가져오기: %name_of_sender%
-  #받은 돈의 값 가져오기: %received_money%
-  #거래 후 돈을 받은 플레이어의 잔액 가져오기: %recipient_money_after_transaction%
-transaction_confirm_to_recipient: #다른 플레이어에게 돈을 보냈을 때 돈을 받은 플레이어에게 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &d%name_of_sender%&f님에게 &6%received_money%&f원을 받았습니다."
-  - "&e[알림] &f잔액: &6%recipient_money_after_transaction%&f원"
-  - ""
+    #config에서 설정한 최솟값 가져오기: %value_of_minimum%
+  minimum_amount_caution: #다른 플레이어에게 돈을 config에서 설정한 최솟값보다 적게 보내려고 하는 경우에 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &f최소 &6%value_of_minimum%&f원 이상부터 보낼 수 있습니다."
+    - ""
 
-  #config에서 설정한 최솟값 가져오기: %value_of_minimum%
-minimum_amount_caution: #다른 플레이어에게 돈을 config에서 설정한 최솟값보다 적게 보내려고 하는 경우에 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &f최소 &6%value_of_minimum%&f원 이상부터 보낼 수 있습니다."
-  - ""
+    #플레이어의 닉네임 가져오기: %name_of_player%
+    #플레이어에게 지급한 돈의 값 가져오기: %increased_money%
+  increase_player_money: #플레이어에게 돈을 지급하였을 때 오피에게 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &d%name_of_player%&f님에게 &6%increased_money%&f원을 지급하였습니다."
+    - ""
 
-  #플레이어의 닉네임 가져오기: %name_of_player%
-  #플레이어에게 지급한 돈의 값 가져오기: %increased_money%
-increase_player_money: #플레이어에게 돈을 지급하였을 때 오피에게 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &d%name_of_player%&f님에게 &6%increased_money%&f원을 지급하였습니다."
-  - ""
+    #플레이어의 닉네임 가져오기: %name_of_player%
+    #플레이어의 돈을 차감한 값 가져오기: %decreased_money%
+  decrease_player_money: #플레이어의 돈을 차감하였을 때 오피에게 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &d%name_of_player%&f님의 돈을 &6%decreased_money%&f원 차감하였습니다."
+    - ""
 
-  #플레이어의 닉네임 가져오기: %name_of_player%
-  #플레이어의 돈을 차감한 값 가져오기: %decreased_money%
-decrease_player_money: #플레이어의 돈을 차감하였을 때 오피에게 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &d%name_of_player%&f님의 돈을 &6%decreased_money%&f원 차감하였습니다."
-  - ""
-
-  #플레이어의 닉네임 가져오기: %name_of_player%
-  #플레이어의 돈을 차감한 값 가져오기: %set_money%
-set_player_money: #플레이어의 돈을 설정하였을 때 오피에게 출력되는 메시지입니다.
-  - ""
-  - "&e[알림] &d%name_of_player%&f님의 돈을 &6%set_money%&f원으로 설정하였습니다."
-  - ""
+    #플레이어의 닉네임 가져오기: %name_of_player%
+    #플레이어의 돈을 차감한 값 가져오기: %set_money%
+  set_player_money: #플레이어의 돈을 설정하였을 때 오피에게 출력되는 메시지입니다.
+    - ""
+    - "&e[알림] &d%name_of_player%&f님의 돈을 &6%set_money%&f원으로 설정하였습니다."
+    - ""

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Uconomy
 version: '${project.version}'
 main: net.teamuni.economy.Uconomy
-api-version: 1.18
+api-version: 1.19
 softdepend:
   - PlaceholderAPI
   - Vault


### PR DESCRIPTION
환경:
마인크래프트 1.19.2 버전, 본섭

테스트: 
1. uconomy 데이터베이스를 생성하고 서버를 오픈 했을 때 테이블이 정상적으로 생성되는지 확인하기.
2. 플레이어가 접속 시, 데이터베이스에 플레이어 정보가 없을 경우 테이블에 새로운 플레이어 데이터가 생성되는지 확인하기.
3. 돈 관련 명령어들이 정상 작동 하는지 확인하기.
4. config.yml에서 "mysql_use: " path에 true 입력 시 MySQL 저장 방식이 정상적으로 사용되는지 확인하기.
5. 플러그인이 비활성화 되면 데이터베이스에 플레이어들의 데이터가 정상적으로 업데이트 되는지 확인하기.

결과:
1. 데이터베이스에 테이블이 생성되어 있지 않을 경우 생성됨.
2. 플레이어 데이터가 없을 경우 테이블에 정상적으로 새 데이터가 생성됨 (시각적으로는 플러그인이 비활성화 되거나 해당 플레이어가 서버를 나갈 경우 확인 가능).
3. 돈 관련 명령어들이 정상 작동함.
4. true면 MySQL 저장 방식, false면 .yml 저장 방식이 작동됨.
5. 플러그인이 비활성화되면 데이트베이스가 정상적으로 업데이트 됨.