### PR TITLE
여러 게임들을 위한 재화 기능 구현하기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.teamuni</groupId>
     <artifactId>Uconomy</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
     <packaging>jar</packaging>
 
     <name>Uconomy</name>

--- a/src/main/java/net/teamuni/economy/Uconomy.java
+++ b/src/main/java/net/teamuni/economy/Uconomy.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import net.teamuni.economy.command.CommandTabCompleter;
 import net.teamuni.economy.command.UconomyCmd;
 import net.teamuni.economy.config.MessageManager;
+import net.teamuni.economy.config.PlayerFileManager;
 import net.teamuni.economy.data.MoneyManager;
 import net.teamuni.economy.data.MoneyUpdater;
 import net.teamuni.economy.data.PlayerDataManager;
@@ -22,6 +23,7 @@ public final class Uconomy extends JavaPlugin {
     private MoneyManager moneyManager;
     private MoneyUpdater moneyUpdater;
     private PlayerDataManager playerDataManager;
+    private PlayerFileManager playerFileManager;
     private boolean isMySQLUse = false;
 
     @Override
@@ -29,7 +31,6 @@ public final class Uconomy extends JavaPlugin {
         this.messageManager = new MessageManager(this);
         this.moneyManager = new MoneyManager(this);
         this.messageManager.createMessagesYml();
-        this.moneyManager.createMoneyDataYml();
         saveDefaultConfig();
         this.isMySQLUse = Boolean.parseBoolean(getConfig().getString("mysql_use"));
         if (isMySQLUse) {
@@ -43,6 +44,7 @@ public final class Uconomy extends JavaPlugin {
                 this.moneyUpdater = null;
             }
         } else {
+            this.playerFileManager = new PlayerFileManager(this);
             this.moneyUpdater = new YMLDatabase(this);
         }
         this.playerDataManager = new PlayerDataManager(this);
@@ -50,8 +52,8 @@ public final class Uconomy extends JavaPlugin {
         Bukkit.getPluginManager().registerEvents(new JoinEvent(this), this);
         getCommand("돈").setExecutor(new UconomyCmd(this));
         getCommand("uconomy").setExecutor(new UconomyCmd(this));
-        getCommand("돈").setTabCompleter(new CommandTabCompleter());
-        getCommand("uconomy").setTabCompleter(new CommandTabCompleter());
+        getCommand("돈").setTabCompleter(new CommandTabCompleter(this));
+        getCommand("uconomy").setTabCompleter(new CommandTabCompleter(this));
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             new UconomyPlaceholders().register();
         }
@@ -60,8 +62,5 @@ public final class Uconomy extends JavaPlugin {
     @Override
     public void onDisable() {
         this.playerDataManager.removeAll();
-        if (!isMySQLUse) {
-            this.moneyManager.save();
-        }
     }
 }

--- a/src/main/java/net/teamuni/economy/command/CommandTabCompleter.java
+++ b/src/main/java/net/teamuni/economy/command/CommandTabCompleter.java
@@ -1,5 +1,6 @@
 package net.teamuni.economy.command;
 
+import net.teamuni.economy.Uconomy;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -12,6 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CommandTabCompleter implements TabCompleter {
+    private final List<String> economyIDs = new ArrayList<>();
+    public CommandTabCompleter(Uconomy instance) {
+        this.economyIDs.addAll(instance.getConfig().getStringList("EconomyID"));
+    }
     @Nullable
     @Override
     public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
@@ -47,6 +52,8 @@ public class CommandTabCompleter implements TabCompleter {
                         tabCompleteMessage.add(onlinePlayers.getName());
                     }
                 } else if (args.length == 3) {
+                    tabCompleteMessage.addAll(economyIDs);
+                } else if (args.length == 4) {
                     tabCompleteMessage.add("금액");
                 }
                 return tabCompleteMessage;
@@ -58,6 +65,8 @@ public class CommandTabCompleter implements TabCompleter {
                             tabCompleteMessage.add(onlinePlayers.getName());
                         }
                     } else if (args.length == 3) {
+                        tabCompleteMessage.addAll(economyIDs);
+                    } else if (args.length == 4) {
                         tabCompleteMessage.add("금액");
                     }
                 }

--- a/src/main/java/net/teamuni/economy/command/UconomyCmd.java
+++ b/src/main/java/net/teamuni/economy/command/UconomyCmd.java
@@ -6,7 +6,6 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,7 +22,7 @@ public class UconomyCmd implements CommandExecutor {
 
     public UconomyCmd(Uconomy instance) {
         this.main = instance;
-        getMessages();
+        this.messageListMap.putAll(instance.getMessageManager().getMessages());
     }
 
     @Override
@@ -35,164 +34,162 @@ public class UconomyCmd implements CommandExecutor {
                         case "확인":
                             switch (args.length) {
                                 case 1 ->
-                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("check_my_money")
-                                                , "%name_of_player%", player.getName()
-                                                , "%player_money%", df.format(main.getMoneyManager().getBalance(player)));
+                                        main.getMessageManager().sendPlayerMoneyInfo(player);
                                 case 2 -> {
                                     if (!player.hasPermission("ucon.manage")) {
-                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                        main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("not_available_command"));
                                         return false;
                                     }
                                     OfflinePlayer target = Bukkit.getOfflinePlayerIfCached(args[1]);
                                     if (target == null) {
-                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                        main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("incorrect_player_name"));
                                         return false;
                                     }
                                     if (!hasAccount(target.getUniqueId())) {
-                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                        main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("incorrect_player_name"));
                                         return false;
                                     }
-                                    main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("check_the_other_player_money")
-                                            , "%name_of_player%", target.getName()
-                                            , "%player_money%", df.format(main.getMoneyManager().getBalance(target)));
+                                    main.getMessageManager().sendPlayerMoneyInfo(player, target);
                                 }
                                 default ->
-                                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                        main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("not_available_command"));
                             }
                             break;
                         case "보내기":
-                            if (args.length != 3) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                            if (args.length != 4) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("not_available_command"));
                                 return false;
                             }
                             OfflinePlayer recipient = Bukkit.getOfflinePlayerIfCached(args[1]);
 
                             if (recipient == null) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("incorrect_player_name"));
                                 return false;
                             }
                             if (!hasAccount(recipient.getUniqueId())) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("incorrect_player_name"));
                                 return false;
                             }
                             if (recipient == player) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("attempt_to_deposit_to_oneself"));
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("attempt_to_deposit_to_oneself"));
                                 return false;
                             }
-                            if (!args[2].matches("[0-9]+")) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("invalid_syntax"));
+                            if (!main.getConfig().getStringList("EconomyID").contains(args[2])) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("invalid_economyID"));
+                            }
+                            if (!args[3].matches("[0-9]+")) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("invalid_syntax"));
                                 return false;
                             }
-                            if (!main.getMoneyManager().has(player, Long.parseLong(args[2]))) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("money_shortage"));
+                            if (!main.getMoneyManager().has(player, args[2], Long.parseLong(args[3]))) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("money_shortage"));
                                 return false;
                             }
-                            if (Long.parseLong(args[2]) < main.getConfig().getLong("minimum_amount")) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("minimum_amount_caution")
+                            if (Long.parseLong(args[3]) < main.getConfig().getLong("minimum_amount")) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("minimum_amount_caution")
                                         , "%value_of_minimum%", df.format(main.getConfig().getLong("minimum_amount")));
                                 return false;
                             }
-                            main.getMoneyManager().withdrawPlayer(player, Long.parseLong(args[2]));
-                            main.getMoneyManager().depositPlayer(recipient, Long.parseLong(args[2]));
+                            main.getMoneyManager().withdrawPlayer(player, args[2], Long.parseLong(args[3]));
+                            main.getMoneyManager().depositPlayer(recipient, args[2], Long.parseLong(args[3]));
 
-                            main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("transaction_confirm_to_sender")
+                            main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("transaction_confirm_to_sender")
+                                    , "%economy_id%" , args[2]
                                     , "%name_of_recipient%", recipient.getName()
-                                    , "%sent_money%", df.format(Long.parseLong(args[2]))
-                                    , "%sender_money_after_transaction%", df.format(main.getMoneyManager().getBalance(player)));
+                                    , "%sent_money%", df.format(Long.parseLong(args[3]))
+                                    , "%sender_money_after_transaction%", df.format(main.getMoneyManager().getBalance(player, args[2])));
 
                             if (recipient.isOnline()) {
                                 Player onlineRecipient = recipient.getPlayer();
                                 assert onlineRecipient != null;
-                                main.getMessageManager().sendTranslatedMsgs(onlineRecipient, this.messageListMap.get("transaction_confirm_to_recipient")
+                                main.getMessageManager().sendTranslatedMessage(onlineRecipient, this.messageListMap.get("transaction_confirm_to_recipient")
+                                        , "%economy_id%" , args[2]
                                         , "%name_of_sender%", player.getName()
-                                        , "%received_money%", df.format(Long.parseLong(args[2]))
-                                        , "%recipient_money_after_transaction%", df.format(main.getMoneyManager().getBalance(recipient)));
+                                        , "%received_money%", df.format(Long.parseLong(args[3]))
+                                        , "%recipient_money_after_transaction%", df.format(main.getMoneyManager().getBalance(recipient, args[2])));
                             }
                             break;
                         case "지급", "차감", "설정":
                             if (!player.hasPermission("ucon.manage")) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("not_available_command"));
                                 return false;
                             }
-                            if (args.length != 3) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                            if (args.length != 4) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("not_available_command"));
                                 return false;
                             }
                             OfflinePlayer target = Bukkit.getOfflinePlayerIfCached(args[1]);
 
                             if (target == null) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("incorrect_player_name"));
                                 return false;
                             }
                             if (!hasAccount(target.getUniqueId())) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("incorrect_player_name"));
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("incorrect_player_name"));
                                 return false;
                             }
-                            if (!args[2].matches("[0-9]+")) {
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("invalid_syntax"));
+                            if (!main.getConfig().getStringList("EconomyID").contains(args[2])) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("invalid_economyID"));
+                                return false;
+                            }
+                            if (!args[3].matches("[0-9]+")) {
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("invalid_syntax"));
                                 return false;
                             }
                             if (args[0].equalsIgnoreCase("지급")) {
-                                main.getMoneyManager().depositPlayer(target, Long.parseLong(args[2]));
+                                main.getMoneyManager().depositPlayer(target, args[2], Long.parseLong(args[3]));
 
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("increase_player_money")
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("increase_player_money")
+                                        , "%economy_id%" , args[2]
                                         , "%name_of_player%", target.getName()
-                                        , "%increased_money%", df.format(Long.parseLong(args[2])));
+                                        , "%increased_money%", df.format(Long.parseLong(args[3])));
                                 return false;
                             }
                             if (args[0].equalsIgnoreCase("차감")) {
-                                main.getMoneyManager().withdrawPlayer(target, Long.parseLong(args[2]));
+                                main.getMoneyManager().withdrawPlayer(target, args[2], Long.parseLong(args[3]));
 
-                                if (main.getMoneyManager().getBalance(target) < 0) {
-                                    main.getMoneyManager().depositPlayer(target, main.getMoneyManager().getBalance(target) * -1);
+                                if (main.getMoneyManager().getBalance(target, args[2]) < 0) {
+                                    main.getMoneyManager().depositPlayer(target, args[2], main.getMoneyManager().getBalance(target, args[2]) * -1);
                                 }
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("decrease_player_money")
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("decrease_player_money")
+                                        , "%economy_id%" , args[2]
                                         , "%name_of_player%", target.getName()
-                                        , "%decreased_money%", df.format(Long.parseLong(args[2])));
+                                        , "%decreased_money%", df.format(Long.parseLong(args[3])));
                                 return false;
                             }
                             if (args[0].equalsIgnoreCase("설정")) {
-                                main.getMoneyManager().withdrawPlayer(target, main.getMoneyManager().getBalance(target));
-                                main.getMoneyManager().depositPlayer(target, Long.parseLong(args[2]));
+                                main.getMoneyManager().withdrawPlayer(target, args[2], main.getMoneyManager().getBalance(target, args[2]));
+                                main.getMoneyManager().depositPlayer(target, args[2], Long.parseLong(args[3]));
 
-                                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("set_player_money")
+                                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("set_player_money")
+                                        , "%economy_id%" , args[2]
                                         , "%name_of_player%", target.getName()
-                                        , "%set_money%", df.format(Long.parseLong(args[2])));
+                                        , "%set_money%", df.format(Long.parseLong(args[3])));
                                 return false;
                             }
                             break;
                         default:
-                            main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("not_available_command"));
+                            main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("not_available_command"));
                             break;
                     }
                 } else {
                     if (player.hasPermission("ucon.manage")) {
-                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("money_command_guide_for_op"));
+                        main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("money_command_guide_for_op"));
                     } else {
-                        main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("money_command_guide"));
+                        main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("money_command_guide"));
                     }
                 }
                 return false;
             }
             if (command.getName().equalsIgnoreCase("uconomy") && args[0].equalsIgnoreCase("reload") && player.hasPermission("ucon.reload")) {
                 main.reloadConfig();
-                main.getMoneyManager().save();
                 main.getMessageManager().reload();
-                getMessages();
-                main.getMessageManager().sendTranslatedMsgs(player, this.messageListMap.get("reload_message"));
+                this.messageListMap.putAll(main.getMessageManager().getMessages());
+                main.getMessageManager().sendTranslatedMessage(player, this.messageListMap.get("reload_message"));
             }
             return false;
         }
         return false;
-    }
-
-    public void getMessages() {
-        ConfigurationSection section = main.getMessageManager().get().getConfigurationSection("Messages");
-        if (section == null) return;
-        for (String key : section.getKeys(false)) {
-            List<String> messages = section.getStringList(key);
-            this.messageListMap.put(key, messages);
-        }
     }
 
     private boolean hasAccount(UUID uuid) {

--- a/src/main/java/net/teamuni/economy/config/MessageManager.java
+++ b/src/main/java/net/teamuni/economy/config/MessageManager.java
@@ -2,20 +2,27 @@ package net.teamuni.economy.config;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.teamuni.economy.Uconomy;
+import net.teamuni.economy.data.PlayerData;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class MessageManager {
     private final Uconomy main;
     private File file = null;
     private FileConfiguration messagesFile = null;
+
     public MessageManager(Uconomy instance) {
         this.main = instance;
     }
@@ -50,7 +57,7 @@ public class MessageManager {
         this.messagesFile = YamlConfiguration.loadConfiguration(file);
     }
 
-    public void sendTranslatedMsgs(Player player, List<String> msgList) {
+    public void sendTranslatedMessage(Player player, List<String> msgList) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {
@@ -63,7 +70,7 @@ public class MessageManager {
         }
     }
 
-    public void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg) {
+    public void sendTranslatedMessage(Player player, List<String> msgList, String msg, String transMsg) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {
@@ -80,7 +87,7 @@ public class MessageManager {
         }
     }
 
-    public void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2) {
+    public void sendTranslatedMessage(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
             for (String msgs : translatedMsgs) {
@@ -99,24 +106,88 @@ public class MessageManager {
         }
     }
 
-    public void sendTranslatedMsgs(Player player, List<String> msgList, String msg, String transMsg, String msg2, String transMsg2, String msg3, String transMsg3) {
+    public void sendTranslatedMessage(Player player, List<String> msgList, String msg1, String transMsg1, String msg2, String transMsg2, String msg3, String transMsg3) {
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
-            List<String> translatedMsgs = PlaceholderAPI.setPlaceholders(player, msgList);
-            for (String msgs : translatedMsgs) {
-                String customMsgs = msgs
-                        .replace(msg, transMsg)
+            List<String> translatedMsgList = PlaceholderAPI.setPlaceholders(player, msgList);
+            for (String msg : translatedMsgList) {
+                String customMsg = msg
+                        .replace(msg1, transMsg1)
                         .replace(msg2, transMsg2)
                         .replace(msg3, transMsg3);
-                player.sendMessage(ChatColor.translateAlternateColorCodes('&', customMsgs));
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', customMsg));
             }
         } else {
-            for (String msgs : msgList) {
-                String customMsgs = msgs
-                        .replace(msg, transMsg)
+            for (String msg : msgList) {
+                String customMsg = msg
+                        .replace(msg1, transMsg1)
                         .replace(msg2, transMsg2)
                         .replace(msg3, transMsg3);
-                player.sendMessage(ChatColor.translateAlternateColorCodes('&', customMsgs));
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', customMsg));
             }
         }
+    }
+
+    public void sendTranslatedMessage(Player player, List<String> msgList, String msg1, String transMsg1
+            , String msg2, String transMsg2, String msg3, String transMsg3, String msg4, String transMsg4) {
+
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            List<String> translatedMsgList = PlaceholderAPI.setPlaceholders(player, msgList);
+            for (String msg : translatedMsgList) {
+                String customMsg = msg
+                        .replace(msg1, transMsg1)
+                        .replace(msg2, transMsg2)
+                        .replace(msg3, transMsg3)
+                        .replace(msg4, transMsg4);
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', customMsg));
+            }
+        } else {
+            for (String msg : msgList) {
+                String customMsg = msg
+                        .replace(msg1, transMsg1)
+                        .replace(msg2, transMsg2)
+                        .replace(msg3, transMsg3)
+                        .replace(msg4, transMsg4);
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', customMsg));
+            }
+        }
+    }
+
+    public void sendPlayerMoneyInfo(Player player) {
+        PlayerData data = main.getPlayerDataManager().getCache(player.getUniqueId());
+        List<String> msgList = getMessages().get("check_my_money");
+        DecimalFormat df = new DecimalFormat("###,###");
+
+        for (Map.Entry<String, Long> entry : data.getMoneyMap().entrySet()) {
+            String placeholder = "%player_money_" + entry.getKey() + "%";
+            msgList.replaceAll(s -> s.contains(placeholder) ? s.replace(placeholder, df.format(entry.getValue())) : s);
+        }
+
+        sendTranslatedMessage(player, msgList
+                , "%name_of_player%", player.getName());
+    }
+
+    public void sendPlayerMoneyInfo(Player messageReceiver, OfflinePlayer player) {
+        PlayerData data = main.getPlayerDataManager().getCache(player.getUniqueId());
+        List<String> msgList = getMessages().get("check_the_other_player_money");
+        DecimalFormat df = new DecimalFormat("###,###");
+
+        for (Map.Entry<String, Long> entry : data.getMoneyMap().entrySet()) {
+            String placeholder = "%player_money_" + entry.getKey() + "%";
+            msgList.replaceAll(s -> s.contains(placeholder) ? s.replace(placeholder, df.format(entry.getValue())) : s);
+        }
+
+        sendTranslatedMessage(messageReceiver, msgList
+                , "%name_of_player%", player.getName());
+    }
+
+    public Map<String, List<String>> getMessages() {
+        Map<String, List<String>> messageListMap = new HashMap<>();
+        ConfigurationSection section = main.getMessageManager().get().getConfigurationSection("Messages");
+        if (section == null) return null;
+        for (String key : section.getKeys(false)) {
+            List<String> messages = section.getStringList(key);
+            messageListMap.put(key, messages);
+        }
+        return messageListMap;
     }
 }

--- a/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
+++ b/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
@@ -38,8 +38,8 @@ public class PlayerFileManager {
             }
         }
         FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(file);
-        for (String money : main.getConfig().getStringList("EconomyID")) {
-            fileConfiguration.set(money, 0);
+        for (String economyID : main.getConfig().getStringList("EconomyID")) {
+            fileConfiguration.set(economyID, 0);
         }
         this.playerFileMap.put(uuid, new PlayerFile(file, fileConfiguration));
     }

--- a/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
+++ b/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
@@ -56,7 +56,6 @@ public class PlayerFileManager {
     }
 
     public void load(UUID uuid) {
-        if (main.isMySQLUse() | this.playerFileMap.containsKey(uuid)) return;
         File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
         FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(file);
         this.playerFileMap.put(uuid, new PlayerFile(file, fileConfiguration));

--- a/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
+++ b/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
@@ -1,0 +1,77 @@
+package net.teamuni.economy.config;
+
+import net.teamuni.economy.Uconomy;
+import net.teamuni.economy.data.PlayerFile;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class PlayerFileManager {
+
+    private final Uconomy main;
+    private File dataFolder = null;
+    private final Map<UUID, PlayerFile> playerFileMap = new HashMap<>();
+    public PlayerFileManager(Uconomy instance) {
+        this.main = instance;
+        createDataFolder();
+    }
+
+    public void createDataFolder() {
+        this.dataFolder = new File(main.getDataFolder(), "data");
+        if (!dataFolder.exists()) {
+            dataFolder.mkdir();
+        }
+    }
+
+    public void createPlayerFile(UUID uuid) {
+        File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
+        if (!file.exists()) {
+            try {
+                file.createNewFile();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(file);
+        for (String money : main.getConfig().getStringList("EconomyID")) {
+            fileConfiguration.set(money, 0);
+        }
+        this.playerFileMap.put(uuid, new PlayerFile(file, fileConfiguration));
+    }
+
+    public void save(UUID uuid) {
+        File file = this.playerFileMap.get(uuid).file();
+        FileConfiguration fileConfiguration = this.playerFileMap.get(uuid).fileConfiguration();
+        if (file == null | fileConfiguration == null | main.isMySQLUse()) return;
+        try {
+            fileConfiguration.save(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void load(UUID uuid) {
+        if (main.isMySQLUse() | this.playerFileMap.containsKey(uuid)) return;
+        File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
+        FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(file);
+        this.playerFileMap.put(uuid, new PlayerFile(file, fileConfiguration));
+    }
+
+    public void remove(UUID uuid) {
+        this.playerFileMap.remove(uuid);
+    }
+
+    public FileConfiguration get(UUID uuid) {
+        return this.playerFileMap.get(uuid).fileConfiguration();
+    }
+
+    public boolean isExist(UUID uuid) {
+        File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
+        return file.exists();
+    }
+}

--- a/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
+++ b/src/main/java/net/teamuni/economy/config/PlayerFileManager.java
@@ -29,7 +29,7 @@ public class PlayerFileManager {
     }
 
     public void createPlayerFile(UUID uuid) {
-        File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
+        File file = new File(this.dataFolder.getPath(), uuid.toString() + ".yml");
         if (!file.exists()) {
             try {
                 file.createNewFile();
@@ -56,7 +56,7 @@ public class PlayerFileManager {
     }
 
     public void load(UUID uuid) {
-        File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
+        File file = new File(this.dataFolder.getPath(), uuid.toString() + ".yml");
         FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(file);
         this.playerFileMap.put(uuid, new PlayerFile(file, fileConfiguration));
     }
@@ -70,7 +70,7 @@ public class PlayerFileManager {
     }
 
     public boolean isExist(UUID uuid) {
-        File file = new File(dataFolder.getPath(), uuid.toString() + ".yml");
+        File file = new File(this.dataFolder.getPath(), uuid.toString() + ".yml");
         return file.exists();
     }
 }

--- a/src/main/java/net/teamuni/economy/data/MoneyManager.java
+++ b/src/main/java/net/teamuni/economy/data/MoneyManager.java
@@ -2,50 +2,15 @@ package net.teamuni.economy.data;
 
 import net.teamuni.economy.Uconomy;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 
-import java.io.File;
-import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.UUID;
 
 public class MoneyManager {
     private final Uconomy main;
-    private File file = null;
-    private FileConfiguration moneyDataFile = null;
 
     public MoneyManager(Uconomy instance) {
         this.main = instance;
-    }
-
-    public void createMoneyDataYml() {
-        file = new File(main.getDataFolder(), "moneydata.yml");
-
-        if (!file.exists()) {
-            main.saveResource("moneydata.yml", false);
-        }
-        moneyDataFile = YamlConfiguration.loadConfiguration(file);
-    }
-
-    public FileConfiguration get() {
-        return moneyDataFile;
-    }
-
-    public void save() {
-        if (this.file == null || this.moneyDataFile == null) return;
-        try {
-            moneyDataFile.save(file);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    public void reload() {
-        if (this.file == null) {
-            this.file = new File(main.getDataFolder(), "moneydata.yml");
-        }
-        moneyDataFile = YamlConfiguration.loadConfiguration(file);
     }
 
     public String format(long amount) {
@@ -65,22 +30,22 @@ public class MoneyManager {
         return result.toString();
     }
 
-    public long getBalance(OfflinePlayer player) {
+    public long getBalance(OfflinePlayer player, String economyID) {
         UUID playerUUID = player.getUniqueId();
-        return main.getPlayerDataManager().getCache(playerUUID).getMoney();
+        return main.getPlayerDataManager().getCache(playerUUID).getMoneyMap().get(economyID);
     }
 
-    public boolean has(OfflinePlayer player, long amount) {
-        return getBalance(player) >= amount;
+    public boolean has(OfflinePlayer player, String economyID, long amount) {
+        return getBalance(player, economyID) >= amount;
     }
 
-    public void withdrawPlayer(OfflinePlayer player, long amount) {
-        long withdrewMoney = getBalance(player) - amount;
-        main.getPlayerDataManager().getCache(player.getUniqueId()).afterWithdraw(withdrewMoney);
+    public void withdrawPlayer(OfflinePlayer player, String economyID, long amount) {
+        long withdrewMoney = getBalance(player, economyID) - amount;
+        main.getPlayerDataManager().getCache(player.getUniqueId()).afterWithdraw(economyID, withdrewMoney);
     }
 
-    public void depositPlayer(OfflinePlayer player, long amount) {
-        long depositedMoney = getBalance(player) + amount;
-        main.getPlayerDataManager().getCache(player.getUniqueId()).afterDeposit(depositedMoney);
+    public void depositPlayer(OfflinePlayer player, String economyID, long amount) {
+        long depositedMoney = getBalance(player, economyID) + amount;
+        main.getPlayerDataManager().getCache(player.getUniqueId()).afterDeposit(economyID, depositedMoney);
     }
 }

--- a/src/main/java/net/teamuni/economy/data/MoneyUpdater.java
+++ b/src/main/java/net/teamuni/economy/data/MoneyUpdater.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 public interface MoneyUpdater {
     void updatePlayerStats(PlayerData playerData);
     PlayerData loadPlayerStats(UUID uuid);
+    PlayerData defaultPlayerStats(UUID uuid);
     boolean hasAccount(UUID uuid);
     boolean createPlayerAccount(OfflinePlayer player);
 }

--- a/src/main/java/net/teamuni/economy/data/PlayerData.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerData.java
@@ -3,10 +3,12 @@ package net.teamuni.economy.data;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.UUID;
+
 @Data
 @AllArgsConstructor
 public class PlayerData {
-    private final String uuid;
+    private final UUID uuid;
     private long money;
     public void afterDeposit(long depositedMoney) {
         this.money = depositedMoney;

--- a/src/main/java/net/teamuni/economy/data/PlayerData.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerData.java
@@ -14,7 +14,7 @@ public class PlayerData {
     public void afterDeposit(String economyID, long depositedMoney) {
         this.moneyMap.put(economyID, depositedMoney);
     }
-    public void afterWithdraw(String economyID, long withDrewMoney) {
-        this.moneyMap.put(economyID, withDrewMoney);
+    public void afterWithdraw(String economyID, long withdrewMoney) {
+        this.moneyMap.put(economyID, withdrewMoney);
     }
 }

--- a/src/main/java/net/teamuni/economy/data/PlayerData.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerData.java
@@ -3,17 +3,18 @@ package net.teamuni.economy.data;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.util.Map;
 import java.util.UUID;
 
 @Data
 @AllArgsConstructor
 public class PlayerData {
     private final UUID uuid;
-    private long money;
-    public void afterDeposit(long depositedMoney) {
-        this.money = depositedMoney;
+    private Map<String, Long> moneyMap;
+    public void afterDeposit(String economyID, long depositedMoney) {
+        this.moneyMap.put(economyID, depositedMoney);
     }
-    public void afterWithdraw(long withDrewMoney) {
-        this.money = withDrewMoney;
+    public void afterWithdraw(String economyID, long withDrewMoney) {
+        this.moneyMap.put(economyID, withDrewMoney);
     }
 }

--- a/src/main/java/net/teamuni/economy/data/PlayerDataManager.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerDataManager.java
@@ -34,7 +34,7 @@ public class PlayerDataManager implements Listener {
                     public @NotNull PlayerData load(@NotNull UUID uuid) {
                         MoneyUpdater updater = instance.getMoneyUpdater();
                         if (updater == null) {
-                            return new PlayerData(uuid.toString(), 0);
+                            return new PlayerData(uuid, null);
                         }
                         return updater.loadPlayerStats(uuid);
                     }

--- a/src/main/java/net/teamuni/economy/data/PlayerFile.java
+++ b/src/main/java/net/teamuni/economy/data/PlayerFile.java
@@ -1,0 +1,8 @@
+package net.teamuni.economy.data;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.File;
+
+public record PlayerFile(File file, FileConfiguration fileConfiguration) {
+}

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -109,26 +109,28 @@ public class MySQLDatabase implements MoneyUpdater {
     @Override
     public PlayerData loadPlayerStats(UUID uuid) {
         try {
-            try (Connection connection = this.sql.getConnection()) {
-                Map<String, Long> map = new HashMap<>();
-                StringBuilder query = new StringBuilder();
+            if (hasAccount(uuid)) {
+                try (Connection connection = this.sql.getConnection()) {
+                    Map<String, Long> map = new HashMap<>();
+                    StringBuilder query = new StringBuilder();
 
-                for (String economyID : this.economyIDs) {
-                    query.append("SELECT ")
-                            .append(economyID)
-                            .append(" FROM uc_stats WHERE uuid = '")
-                            .append(uuid.toString())
-                            .append("'");
+                    for (String economyID : this.economyIDs) {
+                        query.append("SELECT ")
+                                .append(economyID)
+                                .append(" FROM uc_stats WHERE uuid = '")
+                                .append(uuid.toString())
+                                .append("'");
 
-                    try (Statement statement = connection.createStatement()) {
-                        ResultSet result = statement.executeQuery(query.toString());
-                        query.setLength(0);
-                        if (result.next()) {
-                            map.put(economyID, result.getLong(1));
+                        try (Statement statement = connection.createStatement()) {
+                            ResultSet result = statement.executeQuery(query.toString());
+                            query.setLength(0);
+                            if (result.next()) {
+                                map.put(economyID, result.getLong(1));
+                            }
                         }
                     }
+                    return new PlayerData(uuid, map);
                 }
-                return new PlayerData(uuid, map);
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -21,9 +21,9 @@ import java.util.UUID;
 public class MySQLDatabase implements MoneyUpdater {
     private final HikariDataSource sql;
     private final List<String> economyIDs;
-    private final Uconomy main = Uconomy.getPlugin(Uconomy.class);
 
     public MySQLDatabase(String host, int port, String database, String parameters, String user, String password) {
+        Uconomy main = Uconomy.getPlugin(Uconomy.class);
         HikariConfig config = new HikariConfig();
         config.setUsername(user);
         config.setPassword(password);

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -62,10 +62,14 @@ public class MySQLDatabase implements MoneyUpdater {
 
     private void updateColumn() throws SQLException {
         try (Connection connection = this.sql.getConnection()) {
+            StringBuilder query = new StringBuilder();
             for (String economyID : this.economyIDs) {
                 try (Statement statement = connection.createStatement()) {
-                    String query = "ALTER TABLE uc_stats ADD COLUMN IF NOT EXISTS " + economyID + " BIGINT";
-                    statement.execute(query);
+                    query.append("ALTER TABLE uc_stats ADD COLUMN IF NOT EXISTS ")
+                            .append(economyID)
+                            .append(" BIGINT");
+                    statement.execute(query.toString());
+                    query.setLength(0);
                 }
             }
         }
@@ -88,9 +92,9 @@ public class MySQLDatabase implements MoneyUpdater {
                             .append(entry.getValue())
                             .append(", ");
                 }
-                query1.deleteCharAt(query1.length() - 2);
-                query2.deleteCharAt(query2.length() - 2);
-                query3.deleteCharAt(query3.length() - 2);
+                query1.delete(query1.length() - 2, query1.length());
+                query2.delete(query2.length() - 2, query2.length());
+                query3.delete(query3.length() - 2, query3.length());
                 StringBuilder finalQuery = query1.append(query2).append(query3);
 
                 try (Statement statement = connection.createStatement()) {
@@ -107,9 +111,9 @@ public class MySQLDatabase implements MoneyUpdater {
         try {
             try (Connection connection = this.sql.getConnection()) {
                 Map<String, Long> map = new HashMap<>();
+                StringBuilder query = new StringBuilder();
 
                 for (String economyID : this.economyIDs) {
-                    StringBuilder query = new StringBuilder();
                     query.append("SELECT ")
                             .append(economyID)
                             .append(" FROM uc_stats WHERE uuid = '")
@@ -118,6 +122,7 @@ public class MySQLDatabase implements MoneyUpdater {
 
                     try (Statement statement = connection.createStatement()) {
                         ResultSet result = statement.executeQuery(query.toString());
+                        query.setLength(0);
                         if (result.next()) {
                             map.put(economyID, result.getLong(1));
                         }
@@ -169,8 +174,8 @@ public class MySQLDatabase implements MoneyUpdater {
                     query2.append(0)
                             .append(", ");
                 }
-                query1.deleteCharAt(query1.length() - 2);
-                query2.deleteCharAt(query2.length() - 2);
+                query1.delete(query1.length() - 2, query1.length());
+                query2.delete(query2.length() - 2, query2.length());
                 StringBuilder finalQuery = query1.append(query2).append(")");
 
                 try (Statement statement = connection.createStatement()) {

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -139,8 +139,8 @@ public class MySQLDatabase implements MoneyUpdater {
     @Override
     public PlayerData defaultPlayerStats(UUID uuid) {
         Map<String, Long> map = new HashMap<>();
-        for (String money : main.getConfig().getStringList("EconomyID")) {
-            map.put(money, 0L);
+        for (String economyID : this.economyIDs) {
+            map.put(economyID, 0L);
         }
         return new PlayerData(uuid, map);
     }

--- a/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/MySQLDatabase.java
@@ -21,9 +21,9 @@ import java.util.UUID;
 public class MySQLDatabase implements MoneyUpdater {
     private final HikariDataSource sql;
     private final List<String> economyIDs;
+    private final Uconomy main = Uconomy.getPlugin(Uconomy.class);
 
     public MySQLDatabase(String host, int port, String database, String parameters, String user, String password) {
-        Uconomy main = Uconomy.getPlugin(Uconomy.class);
         HikariConfig config = new HikariConfig();
         config.setUsername(user);
         config.setPassword(password);
@@ -133,7 +133,6 @@ public class MySQLDatabase implements MoneyUpdater {
 
     @Override
     public PlayerData defaultPlayerStats(UUID uuid) {
-        Uconomy main = Uconomy.getPlugin(Uconomy.class);
         Map<String, Long> map = new HashMap<>();
         for (String money : main.getConfig().getStringList("EconomyID")) {
             map.put(money, 0L);

--- a/src/main/java/net/teamuni/economy/database/YMLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/YMLDatabase.java
@@ -1,47 +1,69 @@
 package net.teamuni.economy.database;
 
 import net.teamuni.economy.Uconomy;
+import net.teamuni.economy.config.PlayerFileManager;
 import net.teamuni.economy.data.MoneyUpdater;
 import net.teamuni.economy.data.PlayerData;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class YMLDatabase implements MoneyUpdater {
     private final Uconomy main;
-    private final ConfigurationSection section;
+    private final PlayerFileManager playerFileManager;
+    private final List<String> economyIDs = new ArrayList<>();
 
     public YMLDatabase(Uconomy instance) {
         this.main = instance;
-        this.section = instance.getMoneyManager().get().getConfigurationSection("player");
+        this.playerFileManager = instance.getPlayerFileManager();
+        this.economyIDs.addAll(instance.getConfig().getStringList("EconomyID"));
     }
 
     @Override
     public void updatePlayerStats(PlayerData stats) {
-        section.set(stats.getUuid(), stats.getMoney());
+        for (Map.Entry<String, Long> entry : stats.getMoneyMap().entrySet()) {
+            playerFileManager.get(stats.getUuid()).set(entry.getKey(), entry.getValue());
+        }
+        playerFileManager.save(stats.getUuid());
+        main.getPlayerFileManager().remove(stats.getUuid());
     }
 
     @Override
     public PlayerData loadPlayerStats(UUID uuid) {
-        String playerUUID = uuid.toString();
-        if (section.isSet(uuid.toString())) {
-            long money = section.getLong(playerUUID);
-            return new PlayerData(playerUUID, money);
+        if (hasAccount(uuid)) {
+            Map<String, Long> moneyMap = new HashMap<>();
+            for (String economyID : this.economyIDs) {
+                long money = playerFileManager.get(uuid).getLong("economyID");
+                moneyMap.put(economyID, money);
+            }
+            return new PlayerData(uuid, moneyMap);
         }
-        return new PlayerData(playerUUID, 0);
+        return defaultPlayerStats(uuid);
+    }
+
+    @Override
+    public PlayerData defaultPlayerStats(UUID uuid) {
+        Uconomy main = Uconomy.getPlugin(Uconomy.class);
+        Map<String, Long> map = new HashMap<>();
+        for (String money : main.getConfig().getStringList("EconomyID")) {
+            map.put(money, 0L);
+        }
+        return new PlayerData(uuid, map);
     }
 
     @Override
     public boolean hasAccount(UUID uuid) {
-        if (section == null) return false;
-        return section.isSet(uuid.toString());
+        return playerFileManager.isExist(uuid);
     }
 
     @Override
     public boolean createPlayerAccount(OfflinePlayer player) {
-        main.getMoneyManager().get().set("player." + player.getUniqueId(), 0);
+        playerFileManager.createPlayerFile(player.getUniqueId());
         Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");
         return true;
     }

--- a/src/main/java/net/teamuni/economy/database/YMLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/YMLDatabase.java
@@ -38,7 +38,7 @@ public class YMLDatabase implements MoneyUpdater {
         if (hasAccount(uuid)) {
             Map<String, Long> moneyMap = new HashMap<>();
             for (String economyID : this.economyIDs) {
-                long money = playerFileManager.get(uuid).getLong("economyID");
+                long money = playerFileManager.get(uuid).getLong(economyID);
                 moneyMap.put(economyID, money);
             }
             return new PlayerData(uuid, moneyMap);

--- a/src/main/java/net/teamuni/economy/database/YMLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/YMLDatabase.java
@@ -48,7 +48,6 @@ public class YMLDatabase implements MoneyUpdater {
 
     @Override
     public PlayerData defaultPlayerStats(UUID uuid) {
-        Uconomy main = Uconomy.getPlugin(Uconomy.class);
         Map<String, Long> map = new HashMap<>();
         for (String money : main.getConfig().getStringList("EconomyID")) {
             map.put(money, 0L);

--- a/src/main/java/net/teamuni/economy/database/YMLDatabase.java
+++ b/src/main/java/net/teamuni/economy/database/YMLDatabase.java
@@ -27,9 +27,9 @@ public class YMLDatabase implements MoneyUpdater {
     @Override
     public void updatePlayerStats(PlayerData stats) {
         for (Map.Entry<String, Long> entry : stats.getMoneyMap().entrySet()) {
-            playerFileManager.get(stats.getUuid()).set(entry.getKey(), entry.getValue());
+            this.playerFileManager.get(stats.getUuid()).set(entry.getKey(), entry.getValue());
         }
-        playerFileManager.save(stats.getUuid());
+        this.playerFileManager.save(stats.getUuid());
         main.getPlayerFileManager().remove(stats.getUuid());
     }
 
@@ -38,7 +38,7 @@ public class YMLDatabase implements MoneyUpdater {
         if (hasAccount(uuid)) {
             Map<String, Long> moneyMap = new HashMap<>();
             for (String economyID : this.economyIDs) {
-                long money = playerFileManager.get(uuid).getLong(economyID);
+                long money = this.playerFileManager.get(uuid).getLong(economyID);
                 moneyMap.put(economyID, money);
             }
             return new PlayerData(uuid, moneyMap);
@@ -49,20 +49,20 @@ public class YMLDatabase implements MoneyUpdater {
     @Override
     public PlayerData defaultPlayerStats(UUID uuid) {
         Map<String, Long> map = new HashMap<>();
-        for (String money : main.getConfig().getStringList("EconomyID")) {
-            map.put(money, 0L);
+        for (String economyID : this.economyIDs) {
+            map.put(economyID, 0L);
         }
         return new PlayerData(uuid, map);
     }
 
     @Override
     public boolean hasAccount(UUID uuid) {
-        return playerFileManager.isExist(uuid);
+        return this.playerFileManager.isExist(uuid);
     }
 
     @Override
     public boolean createPlayerAccount(OfflinePlayer player) {
-        playerFileManager.createPlayerFile(player.getUniqueId());
+        this.playerFileManager.createPlayerFile(player.getUniqueId());
         Bukkit.getLogger().info("[Uconomy] " + player.getName() + "님의 돈 정보를 생성하였습니다.");
         return true;
     }

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -5,16 +5,14 @@ import net.teamuni.economy.data.MoneyUpdater;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.UUID;
 
-public class JoinAndQuit implements Listener {
+public class JoinEvent implements Listener {
     private final Uconomy main;
-    public JoinAndQuit(Uconomy instance) {
+    public JoinEvent(Uconomy instance) {
         this.main = instance;
     }
 
@@ -31,10 +29,5 @@ public class JoinAndQuit implements Listener {
             main.getPlayerFileManager().load(playerUUID);
             main.getPlayerDataManager().getCache(playerUUID);
         });
-    }
-
-    @EventHandler(priority = EventPriority.LOW)
-    public void onQuit(PlayerQuitEvent event) {
-        main.getPlayerFileManager().remove(event.getPlayer().getUniqueId());
     }
 }

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -8,16 +8,17 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.util.UUID;
 
-public class JoinEvent implements Listener {
+public class JoinAndQuit implements Listener {
     private final Uconomy main;
-    public JoinEvent(Uconomy instance) {
+    public JoinAndQuit(Uconomy instance) {
         this.main = instance;
     }
 
-    @EventHandler(priority = EventPriority.HIGH)
+    @EventHandler
     public void onJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         UUID playerUUID = player.getUniqueId();
@@ -27,7 +28,13 @@ public class JoinEvent implements Listener {
             if (!moneyUpdater.hasAccount(playerUUID)) {
                 moneyUpdater.createPlayerAccount(player);
             }
+            main.getPlayerFileManager().load(playerUUID);
             main.getPlayerDataManager().getCache(playerUUID);
         });
+    }
+
+    @EventHandler(priority = EventPriority.LOW)
+    public void onQuit(PlayerQuitEvent event) {
+        main.getPlayerFileManager().remove(event.getPlayer().getUniqueId());
     }
 }

--- a/src/main/java/net/teamuni/economy/event/JoinEvent.java
+++ b/src/main/java/net/teamuni/economy/event/JoinEvent.java
@@ -26,7 +26,9 @@ public class JoinEvent implements Listener {
             if (!moneyUpdater.hasAccount(playerUUID)) {
                 moneyUpdater.createPlayerAccount(player);
             }
-            main.getPlayerFileManager().load(playerUUID);
+            if (!main.isMySQLUse()) {
+                main.getPlayerFileManager().load(playerUUID);
+            }
             main.getPlayerDataManager().getCache(playerUUID);
         });
     }

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
+import java.util.List;
 
 public class UconomyPlaceholders extends PlaceholderExpansion {
     private final DecimalFormat df = new DecimalFormat("###,###");
@@ -35,9 +36,11 @@ public class UconomyPlaceholders extends PlaceholderExpansion {
 
     @Override
     public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
-        if (params.equalsIgnoreCase("balance")) {
-            PlayerData cacheIfPresent = main.getPlayerDataManager().getCacheIfPresent(player.getUniqueId());
-            return cacheIfPresent == null ? "0" : df.format(cacheIfPresent.getMoney());
+        for (String id : main.getConfig().getStringList("EconomyID")) {
+            if (params.equalsIgnoreCase("balance_" + id)) {
+                PlayerData cacheIfPresent = main.getPlayerDataManager().getCacheIfPresent(player.getUniqueId());
+                return cacheIfPresent == null ? "0" : df.format(cacheIfPresent.getMoneyMap().get(id));
+            }
         }
         if (params.equalsIgnoreCase("minimum_value")) {
             return df.format(main.getConfig().getLong("minimum_amount"));

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
-import java.util.List;
 
 public class UconomyPlaceholders extends PlaceholderExpansion {
     private final DecimalFormat df = new DecimalFormat("###,###");

--- a/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
+++ b/src/main/java/net/teamuni/economy/hooks/UconomyPlaceholders.java
@@ -35,10 +35,10 @@ public class UconomyPlaceholders extends PlaceholderExpansion {
 
     @Override
     public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
-        for (String id : main.getConfig().getStringList("EconomyID")) {
-            if (params.equalsIgnoreCase("balance_" + id)) {
+        for (String economyID : main.getConfig().getStringList("EconomyID")) {
+            if (params.equalsIgnoreCase("balance_" + economyID)) {
                 PlayerData cacheIfPresent = main.getPlayerDataManager().getCacheIfPresent(player.getUniqueId());
-                return cacheIfPresent == null ? "0" : df.format(cacheIfPresent.getMoneyMap().get(id));
+                return cacheIfPresent == null ? "0" : df.format(cacheIfPresent.getMoneyMap().get(economyID));
             }
         }
         if (params.equalsIgnoreCase("minimum_value")) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,9 @@
+#재화 종류
+EconomyID:
+  - "csgo"
+  - "valorant"
+  - "lostark"
+  - "overwatch"
 # 돈 보내기 기능의 최소 금액
 minimum_amount: 1
 #MySQL 사용 여부

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,9 +1,6 @@
 #재화 종류
 EconomyID:
-  - "csgo"
-  - "valorant"
-  - "lostark"
-  - "overwatch"
+  - "game"
 # 돈 보내기 기능의 최소 금액
 minimum_amount: 1
 #MySQL 사용 여부

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -52,10 +52,7 @@ Messages:
     #economyID 자리에는 config.yml에 설정한 EconomyID를 넣어주세요.
   check_my_money: #자신의 돈을 확인할 때 출력되는 메시지입니다.
     - ""
-    - "&fCS:GO : &a%player_money_csgo%&f원"
-    - "&fValorant : &a%player_money_valorant%&f원"
-    - "&fLostArk : &a%player_money_lostark%&f원"
-    - "&fOverwatch : &a%player_money_overwatch%&f원"
+    - "&fGame : &a%player_money_game%&f원"
     - ""
 
     #플레이어의 닉네임 가져오기: %name_of_player%
@@ -64,10 +61,7 @@ Messages:
   check_the_other_player_money: #다른 플레이어의 돈을 확인할 때 출력되는 메시지입니다.
     - ""
     - "&d%name_of_player%&f님이 보유하고 있는 돈은 아래와 같습니다."
-    - "&fCS:GO : &a%player_money_csgo%&f원"
-    - "&fValorant : &a%player_money_valorant%&f원"
-    - "&fLostArk : &a%player_money_lostark%&f원"
-    - "&fOverwatch : &a%player_money_overwatch%&f원"
+    - "&fGame : &a%player_money_game%&f원"
     - ""
 
     #돈을 받은 플레이어의 닉네임 가져오기: %name_of_recipient%

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -30,6 +30,10 @@ Messages:
     - ""
     - "&e[알림] &f입력하신 플레이어는 존재하지 않는 플레이어입니다."
     - ""
+  invalid_economyID:
+    - ""
+    - "&e[알림] &f입력하신 재화는 존재하지 않는 재화입니다."
+    - ""
   invalid_syntax: #숫자가 들어가야하는 자리에 문자가 들어간 경우 출력되는 메시지입니다.
     - ""
     - "&e[알림] &f숫자가 들어가야 하는 자리에 문자가 들어갈 수 없습니다."
@@ -44,60 +48,74 @@ Messages:
     - ""
 
     #플레이어의 닉네임 가져오기: %name_of_player%
-    #플레이어의 돈 정보 가져오기: %player_money%
+    #플레이어의 돈 정보 가져오기: %player_money_economyID%
+    #economyID 자리에는 config.yml에 설정한 EconomyID를 넣어주세요.
   check_my_money: #자신의 돈을 확인할 때 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &f현재 &d%name_of_player%&f님이 보유하고 있는 돈은 &6%player_money%&f원입니다."
+    - "&fCS:GO : &a%player_money_csgo%&f원"
+    - "&fValorant : &a%player_money_valorant%&f원"
+    - "&fLostArk : &a%player_money_lostark%&f원"
+    - "&fOverwatch : &a%player_money_overwatch%&f원"
     - ""
 
     #플레이어의 닉네임 가져오기: %name_of_player%
-    #플레이어의 돈 정보 가져오기: %player_money%
+    #플레이어의 돈 정보 가져오기: %player_money_economyID%
+    #economyID 자리에는 config.yml에 설정한 EconomyID를 넣어주세요.
   check_the_other_player_money: #다른 플레이어의 돈을 확인할 때 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &f현재 &d%name_of_player%&f님이 보유하고 있는 돈은 &6%player_money%&f원입니다."
+    - "&d%name_of_player%&f님이 보유하고 있는 돈은 아래와 같습니다."
+    - "&fCS:GO : &a%player_money_csgo%&f원"
+    - "&fValorant : &a%player_money_valorant%&f원"
+    - "&fLostArk : &a%player_money_lostark%&f원"
+    - "&fOverwatch : &a%player_money_overwatch%&f원"
     - ""
 
     #돈을 받은 플레이어의 닉네임 가져오기: %name_of_recipient%
     #보낸 돈의 값 가져오기: %sent_money%
+    #보낸 돈의 EconomyID 가져오기: %economy_id%
     #거래 후 돈을 보낸 플레이어의 잔액 가져오기: %sender_money_after_transaction%
   transaction_confirm_to_sender: #다른 플레이어에게 돈을 보냈을 때 돈을 보낸 플레이어에게 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &d%name_of_recipient%&f님에게 &6%sent_money%&f원을 보냈습니다."
-    - "&e[알림] &f잔액: &6%sender_money_after_transaction%&f원"
+    - "&e[알림] &6%name_of_recipient%&f님에게 %economy_id% 재화 &a%sent_money%&f원을 보냈습니다."
+    - "&e[알림] &f잔액: &a%sender_money_after_transaction%&f원"
     - ""
 
     #돈을 보낸 플레이어의 닉네임 가져오기: %name_of_sender%
     #받은 돈의 값 가져오기: %received_money%
+    #받은 돈의 EconomyID 가져오기: %economy_id%
     #거래 후 돈을 받은 플레이어의 잔액 가져오기: %recipient_money_after_transaction%
   transaction_confirm_to_recipient: #다른 플레이어에게 돈을 보냈을 때 돈을 받은 플레이어에게 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &d%name_of_sender%&f님에게 &6%received_money%&f원을 받았습니다."
-    - "&e[알림] &f잔액: &6%recipient_money_after_transaction%&f원"
+    - "&e[알림] &6%name_of_sender%&f님에게 %economy_id% 재화 &a%received_money%&f원을 받았습니다."
+    - "&e[알림] &f잔액: &a%recipient_money_after_transaction%&f원"
     - ""
 
     #config에서 설정한 최솟값 가져오기: %value_of_minimum%
   minimum_amount_caution: #다른 플레이어에게 돈을 config에서 설정한 최솟값보다 적게 보내려고 하는 경우에 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &f최소 &6%value_of_minimum%&f원 이상부터 보낼 수 있습니다."
+    - "&e[알림] &f최소 &a%value_of_minimum%&f원 이상부터 보낼 수 있습니다."
     - ""
 
     #플레이어의 닉네임 가져오기: %name_of_player%
     #플레이어에게 지급한 돈의 값 가져오기: %increased_money%
+    #지급한 돈의 EconomyID 가져오기: %economy_id%
   increase_player_money: #플레이어에게 돈을 지급하였을 때 오피에게 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &d%name_of_player%&f님에게 &6%increased_money%&f원을 지급하였습니다."
+    - "&e[알림] &6%name_of_player%&f님에게 %economy_id% 재화 &a%increased_money%&f원을 지급하였습니다."
     - ""
 
     #플레이어의 닉네임 가져오기: %name_of_player%
     #플레이어의 돈을 차감한 값 가져오기: %decreased_money%
+    #지급한 돈의 EconomyID 가져오기: %economy_id%
   decrease_player_money: #플레이어의 돈을 차감하였을 때 오피에게 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &d%name_of_player%&f님의 돈을 &6%decreased_money%&f원 차감하였습니다."
+    - "&e[알림] &6%name_of_player%&f님의 %economy_id% 재화를 &a%decreased_money%&f원 차감하였습니다."
     - ""
 
     #플레이어의 닉네임 가져오기: %name_of_player%
     #플레이어의 돈을 차감한 값 가져오기: %set_money%
+    #지급한 돈의 EconomyID 가져오기: %economy_id%
   set_player_money: #플레이어의 돈을 설정하였을 때 오피에게 출력되는 메시지입니다.
     - ""
-    - "&e[알림] &d%name_of_player%&f님의 돈을 &6%set_money%&f원으로 설정하였습니다."
+    - "&e[알림] &6%name_of_player%&f님의 %economy_id% 재화를 &a%set_money%&f원으로 설정하였습니다."
     - ""


### PR DESCRIPTION
테스트 환경: 본섭 1.19.2

테스트:
1. yml 파일 저장 방식을 사용할 때 Uconomy 플러그인 폴더에 data 라는 폴더가 생성되고, 그 안에 플레이어의 UUID가 파일 이름으로 된 yml 파일이 생성되는가?
2. config.yml의 EconomyID에 재화를 추가하면 해당 재화가 MySQL 테이블의 컬럼이나 yml 파일 섹션에 추가가 되는가?
3. MySQL 저장 방식을 사용할 때 데이터베이스에 테이블을 생성하면 config.yml의 EconomyID에 설장한 재화들을 포함해서 생성되는가?
4. 돈 관련 명령어들이 잘 작동하는가?
5. 플레이어가 서버를 나가면 돈 정보가 제대로 저장이 되는가?
6. 플레이어가 재접속을 하면 플레이어의 정보가 중첩으로 생성되지 않는가?
7. Placeholder가 잘 작동하는가? (%uconomy_balance_EconomyID%)

결과:
1.  data 폴더, 플레이어의 UUID가 파일 이름으로 된 yml 파일 모두 잘 생성됨.
2. MySQL 저장 방식의 경우, 테이블의 컬럼에 config.yml의 EconomyID에 추가한 재화의 이름을 가진 컬럼이 추가됨. yml 파일 저장 방식의 경우, config.yml의 EconomyID에 재화를 추가하고 난 뒤로 플레이어가 서버에 한 번은 접속하고 나가야만 yml 파일안에 추가한 재화의 이름을 가진 섹션이 생성됨.
3. 포함되어서 생성됨.
4. MySQL, yml 파일 저장 방식 모두 돈 관련 명령어들이 잘 작동함.
5. MySQL, yml 파일 저장 방식 모두 정보가 정상적으로 저장됨.
6. MySQL, yml 파일 저장 방식 모두 정보가 중첩되어 생성되지 않음.
7. config.yml의 EconomyID에 game, game2를 추가하고 Placeholder를 사용해본 결과 잘 작동됨. (%uconomy_balance_game%, %uconomy_balance_game2%)